### PR TITLE
Do not save chunks when auto saving is disabled

### DIFF
--- a/src/main/java/cn/nukkit/level/format/generic/BaseFullChunk.java
+++ b/src/main/java/cn/nukkit/level/format/generic/BaseFullChunk.java
@@ -395,7 +395,7 @@ public abstract class BaseFullChunk implements FullChunk, ChunkManager {
 
     @Override
     public boolean unload() throws Exception {
-        return this.unload(true, true);
+        return this.unload(provider.getLevel().getAutoSave(), true);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/level/format/generic/BaseLevelProvider.java
+++ b/src/main/java/cn/nukkit/level/format/generic/BaseLevelProvider.java
@@ -83,7 +83,7 @@ public abstract class BaseLevelProvider implements LevelProvider {
     public void unloadChunks() {
         ObjectIterator<BaseFullChunk> iter = chunks.values().iterator();
         while (iter.hasNext()) {
-            iter.next().unload(true, false);
+            iter.next().unload(level.getAutoSave(), false);
             iter.remove();
         }
     }


### PR DESCRIPTION
This fixes #272

Currently Nukkit saves the chunks when the level is unloaded even if auto saving is disabled. This pr makes chunks to be never saved automatically if the auto saving is disabled (and if none of your plugins does the saving or you don't use the save-all command). **The question is: Should disabling auto save only disable the auto save task or also the saving Nukkit does when levels are unloaded?** Not saving chunks at all when the auto saving is disabled may be usefull on minigame servers where the worlds will be reseted after a match anyways.