### PR TITLE
[2.0] Scoreboard Support and API

### DIFF
--- a/src/main/java/cn/nukkit/player/Player.java
+++ b/src/main/java/cn/nukkit/player/Player.java
@@ -3431,13 +3431,13 @@ public class Player extends Human implements CommandSender, InventoryHolder, Chu
      * @param scoreboard the scoreboard to set
      */
     public void setScoreboard(@Nullable Scoreboard scoreboard) {
-        this.scoreboard = scoreboard;
         if (this.scoreboard != null) {
             ((NukkitScoreboard) this.scoreboard).hide(this);
         }
         if (scoreboard != null) {
             ((NukkitScoreboard) scoreboard).show(this);
         }
+        this.scoreboard = scoreboard;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/player/Player.java
+++ b/src/main/java/cn/nukkit/player/Player.java
@@ -65,6 +65,8 @@ import cn.nukkit.registry.BlockRegistry;
 import cn.nukkit.registry.CommandRegistry;
 import cn.nukkit.registry.EntityRegistry;
 import cn.nukkit.registry.ItemRegistry;
+import cn.nukkit.scoreboard.Scoreboard;
+import cn.nukkit.scoreboard.impl.NukkitScoreboard;
 import cn.nukkit.utils.*;
 import co.aikar.timings.Timing;
 import co.aikar.timings.Timings;
@@ -91,6 +93,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import lombok.extern.log4j.Log4j2;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.*;
@@ -235,6 +238,8 @@ public class Player extends Human implements CommandSender, InventoryHolder, Chu
     public FishingHook fishing = null;
 
     private final PlayerChunkManager chunkManager = new PlayerChunkManager(this);
+
+    private Scoreboard scoreboard;
 
     public int packetsRecieved;
 
@@ -2090,6 +2095,10 @@ public class Player extends Human implements CommandSender, InventoryHolder, Chu
                 if (this.fishing != null) {
                     this.stopFishing(false);
                 }
+                if (this.scoreboard != null) {
+                    ((NukkitScoreboard) this.scoreboard).getPlayers().remove(this);
+                    this.scoreboard = null;
+                }
             }
 
             for (Player player : new ArrayList<>(this.server.getOnlinePlayers().values())) {
@@ -3402,6 +3411,33 @@ public class Player extends Human implements CommandSender, InventoryHolder, Chu
         }
 
         return false;
+    }
+
+    /**
+     * Gets the current {@link Scoreboard} of
+     * the player
+     *
+     * @return the current scoreboard of the player
+     */
+    @Nullable
+    public Scoreboard getScoreboard() {
+        return this.scoreboard;
+    }
+
+    /**
+     * Sets the player's {@link Scoreboard} to the
+     * specified scoreboard
+     *
+     * @param scoreboard the scoreboard to set
+     */
+    public void setScoreboard(@Nullable Scoreboard scoreboard) {
+        this.scoreboard = scoreboard;
+        if (this.scoreboard != null) {
+            ((NukkitScoreboard) this.scoreboard).hide(this);
+        }
+        if (scoreboard != null) {
+            ((NukkitScoreboard) scoreboard).show(this);
+        }
     }
 
     @Override

--- a/src/main/java/cn/nukkit/scoreboard/DisplayMode.java
+++ b/src/main/java/cn/nukkit/scoreboard/DisplayMode.java
@@ -1,0 +1,26 @@
+package cn.nukkit.scoreboard;
+
+/**
+ * Represents where a {@link ScoreboardObjective} should be displayed
+ * on a {@link Scoreboard}.
+ */
+public enum DisplayMode {
+
+    /**
+     * Display mode that shows the objective
+     * in the player list.
+     */
+    LIST,
+
+    /**
+     * Display mode that shows the objective
+     * ion the sidebar.
+     */
+    SIDEBAR,
+
+    /**
+     * Display mode that shows the objective
+     * below the player's name.
+     */
+    BELOWNAME
+}

--- a/src/main/java/cn/nukkit/scoreboard/Score.java
+++ b/src/main/java/cn/nukkit/scoreboard/Score.java
@@ -1,0 +1,83 @@
+package cn.nukkit.scoreboard;
+
+import cn.nukkit.scoreboard.impl.NukkitScore;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a score for a {@link ScoreboardObjective}.
+ */
+public interface Score<T> {
+
+    /**
+     * Gets the {@link ScoreboardObjective} of
+     * this score
+     *
+     * @return the scoreboard objective of this score
+     */
+    ScoreboardObjective getObjective();
+
+    /**
+     * Gets the amount
+     *
+     * @return the amount
+     */
+    int getAmount();
+
+    /**
+     * Sets the amount
+     *
+     * @param value the amount
+     */
+    void setAmount(int value);
+
+    /**
+     * Gets the name of this score
+     *
+     * @return the name of this score
+     */
+    String getName();
+
+    /**
+     * Gets the type of score this is
+     *
+     * @return the type of score this is
+     */
+    ScoreType<T> getScoreType();
+
+    /**
+     * Gets the value of this score
+     *
+     * @return the value of this score
+     */
+    T getValue();
+
+    /**
+     * Sets the value of the score
+     *
+     * @param value the value of the score
+     */
+    void setValue(T value);
+
+    /**
+     * Creates a new instance of a {@link ScoreBuilder}
+     *
+     * @param scoreType the score type
+     * @param <U> the value
+     * @return a new instance of a score builder
+     */
+    static <U> ScoreBuilder<U> builder(ScoreType<U> scoreType) {
+        return NukkitScore.providedBuilder(scoreType);
+    }
+
+    interface ScoreBuilder<T> {
+
+        ScoreBuilder<T> amount(int amount);
+
+        ScoreBuilder<T> name(String name);
+
+        ScoreBuilder<T> value(T value);
+
+        Score<T> build();
+    }
+}

--- a/src/main/java/cn/nukkit/scoreboard/Score.java
+++ b/src/main/java/cn/nukkit/scoreboard/Score.java
@@ -2,8 +2,6 @@ package cn.nukkit.scoreboard;
 
 import cn.nukkit.scoreboard.impl.NukkitScore;
 
-import javax.annotation.Nullable;
-
 /**
  * Represents a score for a {@link ScoreboardObjective}.
  */

--- a/src/main/java/cn/nukkit/scoreboard/ScoreType.java
+++ b/src/main/java/cn/nukkit/scoreboard/ScoreType.java
@@ -1,0 +1,50 @@
+package cn.nukkit.scoreboard;
+
+import cn.nukkit.entity.Entity;
+import cn.nukkit.player.Player;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+/**
+ * Represents the score type for the
+ * {@link Score} in a {@link Scoreboard}.
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ScoreType<T> {
+
+    /**
+     * A score type where the value is
+     * that of a player.
+     */
+    public static final ScoreType<Player> PLAYER = new ScoreType<>("player", Player.class);
+
+    /**
+     * A score type where the value is
+     * that of an entity.
+     */
+    public static final ScoreType<Entity> ENTITY = new ScoreType<>("entity", Entity.class);
+
+    /**
+     * A fake score type that does not
+     * require an entity or player.
+     */
+    public static final ScoreType<String> FAKE = new ScoreType<>("fake", String.class);
+
+    private String name;
+    private Class<T> supportedType;
+
+    /**
+     * Gets the supported value type for
+     * this score type
+     *
+     * @return the supported value for this score type
+     */
+    public Class<T> getSupportedType() {
+        return supportedType;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/main/java/cn/nukkit/scoreboard/Scoreboard.java
+++ b/src/main/java/cn/nukkit/scoreboard/Scoreboard.java
@@ -1,0 +1,58 @@
+package cn.nukkit.scoreboard;
+
+import cn.nukkit.player.Player;
+import cn.nukkit.scoreboard.impl.NukkitScoreboard;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+/**
+ * Represents a scoreboard in the game, which can contain
+ * various information and be used to display data for players.
+ */
+public interface Scoreboard {
+
+    /**
+     * Gets the {@link ScoreboardObjective} with the specified name
+     *
+     * @param objectiveName the name of the objective
+     * @return the objective with the specified name
+     */
+    @Nullable
+    ScoreboardObjective getObjective(String objectiveName);
+
+    /**
+     * Registers a new {@link ScoreboardObjective} to the scoreboard
+     * @param objective the objective
+     */
+    void registerObjective(ScoreboardObjective objective);
+
+    /**
+     * Deregisters a {@link ScoreboardObjective} from the scoreboard.
+     *
+     * @param name the name of the objective
+     */
+    void deregisterObjective(String name);
+
+    /**
+     * Creates a new instance of a {@link ScoreboardBuilder}
+     *
+     * @return a new instance of a scoreboard builder
+     */
+    static ScoreboardBuilder builder() {
+        return NukkitScoreboard.providedBuilder();
+    }
+
+    interface ScoreboardBuilder {
+
+        ScoreboardBuilder objectives(ScoreboardObjective... objectives);
+
+        ScoreboardBuilder players(Player... players);
+
+        default ScoreboardBuilder players(Collection<Player> players) {
+            return this.players(players.toArray(new Player[0]));
+        }
+
+        Scoreboard build();
+    }
+}

--- a/src/main/java/cn/nukkit/scoreboard/ScoreboardCriteria.java
+++ b/src/main/java/cn/nukkit/scoreboard/ScoreboardCriteria.java
@@ -1,0 +1,12 @@
+package cn.nukkit.scoreboard;
+
+/**
+ * The criterion for a {@link ScoreboardObjective}.
+ */
+public enum ScoreboardCriteria {
+
+    /**
+     * Dummy scoreboard criterion.
+     */
+    DUMMY
+}

--- a/src/main/java/cn/nukkit/scoreboard/ScoreboardObjective.java
+++ b/src/main/java/cn/nukkit/scoreboard/ScoreboardObjective.java
@@ -1,0 +1,133 @@
+package cn.nukkit.scoreboard;
+
+import cn.nukkit.scoreboard.impl.NukkitScoreboardObjective;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents an objective in a {@link Scoreboard}.
+ */
+public interface ScoreboardObjective {
+
+    /**
+     * Gets the name of this objective
+     *
+     * @return the name of this objective
+     */
+    String getName();
+
+    /**
+     * Gets the {@link DisplayMode} of this objective
+     *
+     * @return the display mode of this objective
+     */
+    DisplayMode getDisplayMode();
+
+    /**
+     * Gets the {@link SortOrder} of this objective
+     *
+     * @return the sort order of this objective
+     */
+    SortOrder getSortOrder();
+
+    /**
+     * Sets the {@link SortOrder} of the {@link Score}s
+     * in this objective
+     *
+     * @param sortOrder the sort order of all the scores
+     */
+    void setSortOrder(SortOrder sortOrder);
+
+    /**
+     * Gets the display name of this objective
+     *
+     * @return the display name of this objective
+     */
+    String getDisplayName();
+
+    /**
+     * Sets the display name of this objective
+     *
+     * @param displayName the display name of this objective
+     */
+    void setDisplayName(String displayName);
+
+    /**
+     * Gets the {@link ScoreboardCriteria} of this objective
+     *
+     * @return the criteria of this objective
+     */
+    ScoreboardCriteria getCriteria();
+
+    /**
+     * Gets the {@link Score} from the specified name
+     *
+     * @param name the name of the score
+     * @return the score from the specified name
+     */
+    @Nullable
+    Score<?> getScore(String name);
+
+    /**
+     * Gets the {@link Score} with the specified {@link ScoreType}
+     *
+     * @param scoreType the score type
+     * @param <T> the value
+     * @return the score with the specified score type
+     */
+    @Nullable
+    <T> Score<T> getScore(String name, ScoreType<T> scoreType);
+
+    /**
+     * Gets or creates a {@link Score} with the specified name,
+     * {@link ScoreType}, and input
+     *
+     * @param name the name of the score
+     * @param type the score type
+     * @param input the input of the score
+     * @param value the value of the score
+     * @param <T> the value
+     * @return the score with the specified name, scoretype and input
+     */
+    <T> Score<T> getOrCreateScore(String name, ScoreType<T> type, T input, int value);
+
+    /**
+     * Removes the {@link Score} with the specified name
+     *
+     * @param name the name of the score
+     */
+    void removeScore(String name);
+
+    /**
+     * Registers a score
+     *
+     * @param score the score to register
+     */
+    void createScore(Score<?> score);
+
+    /**
+     * Creates a new instance of a {@link ScoreboardObjectiveBuilder}
+     *
+     * @return a new instance of an objective builder
+     */
+    static ScoreboardObjectiveBuilder builder() {
+        return NukkitScoreboardObjective.providedBuilder();
+    }
+
+    interface ScoreboardObjectiveBuilder {
+
+        ScoreboardObjectiveBuilder name(String name);
+
+        ScoreboardObjectiveBuilder displayMode(DisplayMode displayMode);
+
+        ScoreboardObjectiveBuilder sortOrder(SortOrder sortOrder);
+
+        ScoreboardObjectiveBuilder displayName(String displayName);
+
+        ScoreboardObjectiveBuilder criteria(ScoreboardCriteria criteria);
+
+        ScoreboardObjectiveBuilder scores(Score<?>... scores);
+
+        ScoreboardObjective build();
+    }
+}

--- a/src/main/java/cn/nukkit/scoreboard/SortOrder.java
+++ b/src/main/java/cn/nukkit/scoreboard/SortOrder.java
@@ -1,0 +1,17 @@
+package cn.nukkit.scoreboard;
+
+/**
+ * Represents the sort order for a {@link ScoreboardObjective}
+ */
+public enum SortOrder {
+
+    /**
+     * An ascending sort order.
+     */
+    ASCENDING,
+
+    /**
+     * A descending sort order.
+     */
+    DESCENDING
+}

--- a/src/main/java/cn/nukkit/scoreboard/impl/NukkitScore.java
+++ b/src/main/java/cn/nukkit/scoreboard/impl/NukkitScore.java
@@ -4,6 +4,7 @@ import cn.nukkit.Server;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.scoreboard.Score;
 import cn.nukkit.scoreboard.ScoreType;
+import com.google.common.base.Preconditions;
 import com.nukkitx.protocol.bedrock.data.ScoreInfo;
 import com.nukkitx.protocol.bedrock.packet.SetScorePacket;
 import lombok.Getter;
@@ -109,6 +110,8 @@ public class NukkitScore<T> implements Score<T> {
 
         @Override
         public NukkitScore<T> build() {
+            Preconditions.checkNotNull(this.score.name, "Score name cannot be null.");
+            Preconditions.checkNotNull(this.score.value, "Score value cannot be null.");
             return this.score;
         }
     }

--- a/src/main/java/cn/nukkit/scoreboard/impl/NukkitScore.java
+++ b/src/main/java/cn/nukkit/scoreboard/impl/NukkitScore.java
@@ -1,0 +1,115 @@
+package cn.nukkit.scoreboard.impl;
+
+import cn.nukkit.Server;
+import cn.nukkit.entity.Entity;
+import cn.nukkit.scoreboard.Score;
+import cn.nukkit.scoreboard.ScoreType;
+import com.nukkitx.protocol.bedrock.data.ScoreInfo;
+import com.nukkitx.protocol.bedrock.packet.SetScorePacket;
+import lombok.Getter;
+
+import java.util.Collections;
+
+@Getter
+public class NukkitScore<T> implements Score<T> {
+
+    protected NukkitScoreboardObjective objective;
+    protected long id;
+
+    private int amount;
+    private String name;
+
+    private ScoreType<T> scoreType;
+    private T value;
+
+    private NukkitScore() {
+    }
+
+    @Override
+    public void setAmount(int amount) {
+        this.amount = amount;
+
+        ScoreInfo scoreInfo = this.createScoreInfo();
+        SetScorePacket setScorePacket = new SetScorePacket();
+        setScorePacket.setInfos(Collections.singletonList(scoreInfo));
+
+        setScorePacket.setAction(SetScorePacket.Action.REMOVE);
+        Server.broadcastPacket(this.objective.scoreboard.getPlayers(), setScorePacket);
+
+        setScorePacket = new SetScorePacket();
+        setScorePacket.setAction(SetScorePacket.Action.SET);
+        setScorePacket.setInfos(Collections.singletonList(scoreInfo));
+        Server.broadcastPacket(this.objective.scoreboard.getPlayers(), setScorePacket);
+    }
+
+    @Override
+    public void setValue(T value) {
+        this.value = value;
+
+        ScoreInfo scoreInfo = this.createScoreInfo();
+        SetScorePacket setScorePacket = new SetScorePacket();
+        setScorePacket.setInfos(Collections.singletonList(scoreInfo));
+
+        setScorePacket.setAction(SetScorePacket.Action.REMOVE);
+        Server.broadcastPacket(this.objective.scoreboard.getPlayers(), setScorePacket);
+
+        setScorePacket = new SetScorePacket();
+        setScorePacket.setAction(SetScorePacket.Action.SET);
+        setScorePacket.setInfos(Collections.singletonList(scoreInfo));
+        Server.broadcastPacket(this.objective.scoreboard.getPlayers(), setScorePacket);
+    }
+
+    protected ScoreInfo createScoreInfo() {
+        if (this.scoreType == ScoreType.PLAYER || this.scoreType == ScoreType.ENTITY) {
+            return new ScoreInfo(
+                    this.id,
+                    this.objective.getName(),
+                    this.amount,
+                    ScoreInfo.ScorerType.valueOf(this.scoreType.toString().toUpperCase()),
+                    ((Entity) this.value).getUniqueId()
+            );
+        }
+        return new ScoreInfo(
+                this.id,
+                this.objective.getName(),
+                this.amount,
+                (String) this.value
+        );
+    }
+
+    public static <U> NukkitScoreBuilder<U> providedBuilder(ScoreType<U> scoreType) {
+        return new NukkitScoreBuilder<>(scoreType);
+    }
+
+    public static class NukkitScoreBuilder<T> implements ScoreBuilder<T> {
+
+        private final NukkitScore<T> score = new NukkitScore<>();
+
+        public NukkitScoreBuilder(ScoreType<T> scoreType) {
+            this.score.scoreType = scoreType;
+        }
+
+        @Override
+        public NukkitScoreBuilder<T> amount(int amount) {
+            this.score.amount = amount;
+            return this;
+        }
+
+        @Override
+        public NukkitScoreBuilder<T> name(String name) {
+            this.score.name = name;
+            return this;
+        }
+
+        @Override
+        public NukkitScoreBuilder<T> value(T value) {
+            this.score.value = value;
+            return this;
+        }
+
+        @Override
+        public NukkitScore<T> build() {
+            return this.score;
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/scoreboard/impl/NukkitScoreboard.java
+++ b/src/main/java/cn/nukkit/scoreboard/impl/NukkitScoreboard.java
@@ -1,0 +1,128 @@
+package cn.nukkit.scoreboard.impl;
+
+import cn.nukkit.Server;
+import cn.nukkit.player.Player;
+import cn.nukkit.scoreboard.Score;
+import cn.nukkit.scoreboard.Scoreboard;
+import cn.nukkit.scoreboard.ScoreboardObjective;
+import com.nukkitx.protocol.bedrock.data.ScoreInfo;
+import com.nukkitx.protocol.bedrock.packet.RemoveObjectivePacket;
+import com.nukkitx.protocol.bedrock.packet.SetDisplayObjectivePacket;
+import com.nukkitx.protocol.bedrock.packet.SetScorePacket;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class NukkitScoreboard implements Scoreboard {
+
+    private final Map<String, ScoreboardObjective> objectives = new HashMap<>();
+
+    @Getter
+    private final Set<Player> players = new HashSet<>();
+
+    private NukkitScoreboard() {
+    }
+
+    @Override
+    public ScoreboardObjective getObjective(String objectiveName) {
+        return this.objectives.get(objectiveName);
+    }
+
+    @Override
+    public void registerObjective(ScoreboardObjective objective) {
+        this.objectives.put(objective.getName(), objective);
+
+        ((NukkitScoreboardObjective) objective).scoreboard = this;
+
+        SetDisplayObjectivePacket displayObjectivePacket = new SetDisplayObjectivePacket();
+        displayObjectivePacket.setObjectiveId(objective.getName());
+        displayObjectivePacket.setCriteria(objective.getCriteria().name().toLowerCase());
+        displayObjectivePacket.setDisplayName(objective.getDisplayName());
+        displayObjectivePacket.setDisplaySlot(objective.getDisplayMode().name().toLowerCase());
+        displayObjectivePacket.setSortOrder(objective.getSortOrder().ordinal());
+        Server.broadcastPacket(this.players, displayObjectivePacket);
+    }
+
+    @Override
+    public void deregisterObjective(String name) {
+        ScoreboardObjective objective = this.objectives.remove(name);
+
+        RemoveObjectivePacket removeObjectivePacket = new RemoveObjectivePacket();
+        removeObjectivePacket.setObjectiveId(objective.getName());
+        Server.broadcastPacket(this.players, removeObjectivePacket);
+    }
+
+    public void show(Player player) {
+        if (this.players.contains(player)) {
+            return;
+        }
+        this.players.add(player);
+
+        for (ScoreboardObjective objective : this.objectives.values()) {
+            SetDisplayObjectivePacket displayObjectivePacket = new SetDisplayObjectivePacket();
+            displayObjectivePacket.setObjectiveId(objective.getName());
+            displayObjectivePacket.setCriteria(objective.getCriteria().name().toLowerCase());
+            displayObjectivePacket.setDisplayName(objective.getDisplayName());
+            displayObjectivePacket.setDisplaySlot(objective.getDisplayMode().name().toLowerCase());
+            displayObjectivePacket.setSortOrder(objective.getSortOrder().ordinal());
+            Server.broadcastPacket(this.players, displayObjectivePacket);
+
+            List<ScoreInfo> scoreInfos = new ArrayList<>();
+            for (Score<?> score : ((NukkitScoreboardObjective) objective).scores.values()) {
+                scoreInfos.add(((NukkitScore<?>) score).createScoreInfo());
+            }
+
+            SetScorePacket setScorePacket = new SetScorePacket();
+            setScorePacket.setAction(SetScorePacket.Action.SET);
+            setScorePacket.setInfos(scoreInfos);
+            Server.broadcastPacket(this.players, setScorePacket);
+        }
+    }
+
+    public void hide(Player player) {
+        if (!this.players.contains(player)) {
+            return;
+        }
+        this.players.remove(player);
+
+        for (ScoreboardObjective objective : this.objectives.values()) {
+            RemoveObjectivePacket removeObjectivePacket = new RemoveObjectivePacket();
+            removeObjectivePacket.setObjectiveId(objective.getName());
+            player.sendPacket(removeObjectivePacket);
+        }
+    }
+
+    public static ScoreboardBuilder providedBuilder() {
+        return new NukkitScoreboardBuilder();
+    }
+
+    public static class NukkitScoreboardBuilder implements ScoreboardBuilder {
+
+        private final NukkitScoreboard scoreboard = new NukkitScoreboard();
+
+        @Override
+        public ScoreboardBuilder objectives(ScoreboardObjective... objectives) {
+            for (ScoreboardObjective objective : objectives) {
+                this.scoreboard.objectives.put(objective.getName(), objective);
+            }
+            return this;
+        }
+
+        @Override
+        public ScoreboardBuilder players(Player... players) {
+            this.scoreboard.players.addAll(Arrays.asList(players));
+            return this;
+        }
+
+        @Override
+        public Scoreboard build() {
+            return this.scoreboard;
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/scoreboard/impl/NukkitScoreboardObjective.java
+++ b/src/main/java/cn/nukkit/scoreboard/impl/NukkitScoreboardObjective.java
@@ -7,6 +7,7 @@ import cn.nukkit.scoreboard.ScoreType;
 import cn.nukkit.scoreboard.ScoreboardCriteria;
 import cn.nukkit.scoreboard.ScoreboardObjective;
 import cn.nukkit.scoreboard.SortOrder;
+import com.google.common.base.Preconditions;
 import com.nukkitx.protocol.bedrock.data.ScoreInfo;
 import com.nukkitx.protocol.bedrock.packet.RemoveObjectivePacket;
 import com.nukkitx.protocol.bedrock.packet.SetDisplayObjectivePacket;
@@ -183,6 +184,9 @@ public class NukkitScoreboardObjective implements ScoreboardObjective {
 
         @Override
         public ScoreboardObjective build() {
+            Preconditions.checkNotNull(this.objective.name, "Name cannot be null");
+            Preconditions.checkNotNull(this.objective.displayMode, "Display mode cannot be null.");
+            Preconditions.checkNotNull(this.objective.displayName, "Display name cannot be null.");
             return this.objective;
         }
     }

--- a/src/main/java/cn/nukkit/scoreboard/impl/NukkitScoreboardObjective.java
+++ b/src/main/java/cn/nukkit/scoreboard/impl/NukkitScoreboardObjective.java
@@ -1,0 +1,189 @@
+package cn.nukkit.scoreboard.impl;
+
+import cn.nukkit.Server;
+import cn.nukkit.scoreboard.DisplayMode;
+import cn.nukkit.scoreboard.Score;
+import cn.nukkit.scoreboard.ScoreType;
+import cn.nukkit.scoreboard.ScoreboardCriteria;
+import cn.nukkit.scoreboard.ScoreboardObjective;
+import cn.nukkit.scoreboard.SortOrder;
+import com.nukkitx.protocol.bedrock.data.ScoreInfo;
+import com.nukkitx.protocol.bedrock.packet.RemoveObjectivePacket;
+import com.nukkitx.protocol.bedrock.packet.SetDisplayObjectivePacket;
+import com.nukkitx.protocol.bedrock.packet.SetScorePacket;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Getter
+public class NukkitScoreboardObjective implements ScoreboardObjective {
+
+    protected NukkitScoreboard scoreboard;
+    protected AtomicLong id = new AtomicLong(0);
+
+    private String name;
+    private DisplayMode displayMode;
+    private SortOrder sortOrder = SortOrder.DESCENDING;
+
+    private String displayName;
+    private ScoreboardCriteria criteria = ScoreboardCriteria.DUMMY;
+
+    protected final Map<String, Score<?>> scores = new HashMap<>();
+
+    private NukkitScoreboardObjective() {
+    }
+
+    @Override
+    public void setSortOrder(SortOrder sortOrder) {
+        this.sortOrder = sortOrder;
+
+        this.refresh();
+    }
+
+    @Override
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+
+        this.refresh();
+    }
+
+    @Override
+    public Score<?> getScore(String name) {
+        return this.scores.get(name);
+    }
+
+    @Override
+    public <T> Score<T> getScore(String name, ScoreType<T> scoreType) {
+        Score<?> score = this.scores.get(name);
+        if (score == null) {
+            return null;
+        }
+        if (!scoreType.getSupportedType().isAssignableFrom(score.getValue().getClass())) {
+            return null;
+        }
+        return (Score<T>) score;
+    }
+
+    @Override
+    public <T> Score<T> getOrCreateScore(String name, ScoreType<T> type, T value, int amount) {
+        Score<?> score = this.scores.get(name);
+        if (score != null) {
+            if (!value.getClass().isAssignableFrom(score.getValue().getClass())) {
+                throw new IllegalArgumentException("Score " + name + " for type " + score.getValue().getClass() + " is not an instance of " + value.getClass() + "!");
+            }
+            return (Score<T>) this.scores.get(name);
+        }
+        score = Score.builder(type).value(value).name(name).amount(amount).build();
+        createScore(score);
+        return (Score<T>) score;
+    }
+
+    @Override
+    public void createScore(Score<?> score) {
+        this.scores.put(score.getName(), score);
+
+        NukkitScore<?> scoreImpl = (NukkitScore<?>) score;
+        scoreImpl.objective = this;
+        scoreImpl.id = this.id.getAndIncrement();
+
+        SetScorePacket setScorePacket = new SetScorePacket();
+        setScorePacket.setAction(SetScorePacket.Action.SET);
+        setScorePacket.setInfos(Collections.singletonList(scoreImpl.createScoreInfo()));
+        Server.broadcastPacket(this.scoreboard.getPlayers(), setScorePacket);
+    }
+
+    @Override
+    public void removeScore(String name) {
+        NukkitScore<?> scoreImpl = (NukkitScore<?>) this.scores.remove(name);
+        if (scoreImpl == null) {
+            return;
+        }
+
+        SetScorePacket setScorePacket = new SetScorePacket();
+        setScorePacket.setAction(SetScorePacket.Action.REMOVE);
+        setScorePacket.setInfos(Collections.singletonList(scoreImpl.createScoreInfo()));
+        Server.broadcastPacket(this.scoreboard.getPlayers(), setScorePacket);
+    }
+
+    protected void refresh() {
+        // We need to remove the objective so we can resend it
+        RemoveObjectivePacket removeObjectivePacket = new RemoveObjectivePacket();
+        removeObjectivePacket.setObjectiveId(this.getName());
+        Server.broadcastPacket(this.scoreboard.getPlayers(), removeObjectivePacket);
+
+        SetDisplayObjectivePacket displayObjectivePacket = new SetDisplayObjectivePacket();
+        displayObjectivePacket.setObjectiveId(this.name);
+        displayObjectivePacket.setCriteria(this.criteria.name().toLowerCase());
+        displayObjectivePacket.setDisplayName(this.displayName);
+        displayObjectivePacket.setDisplaySlot(this.displayMode.name().toLowerCase());
+        displayObjectivePacket.setSortOrder(this.sortOrder.ordinal());
+        Server.broadcastPacket(this.scoreboard.getPlayers(), displayObjectivePacket);
+
+        List<ScoreInfo> scoreInfos = new ArrayList<>();
+        for (Score<?> score : this.scores.values()) {
+            scoreInfos.add(((NukkitScore<?>) score).createScoreInfo());
+        }
+
+        SetScorePacket setScorePacket = new SetScorePacket();
+        setScorePacket.setAction(SetScorePacket.Action.SET);
+        setScorePacket.setInfos(scoreInfos);
+        Server.broadcastPacket(this.scoreboard.getPlayers(), setScorePacket);
+    }
+
+    public static ScoreboardObjectiveBuilder providedBuilder() {
+        return new NukkitScoreboardObjectiveBuilder();
+    }
+
+    public static class NukkitScoreboardObjectiveBuilder implements ScoreboardObjectiveBuilder {
+
+        private final NukkitScoreboardObjective objective = new NukkitScoreboardObjective();
+
+        @Override
+        public ScoreboardObjectiveBuilder name(String name) {
+            this.objective.name = name;
+            return this;
+        }
+
+        @Override
+        public ScoreboardObjectiveBuilder displayMode(DisplayMode displayMode) {
+            this.objective.displayMode = displayMode;
+            return this;
+        }
+
+        @Override
+        public ScoreboardObjectiveBuilder sortOrder(SortOrder sortOrder) {
+            this.objective.sortOrder = sortOrder;
+            return this;
+        }
+
+        @Override
+        public ScoreboardObjectiveBuilder displayName(String displayName) {
+            this.objective.displayName = displayName;
+            return this;
+        }
+
+        @Override
+        public ScoreboardObjectiveBuilder criteria(ScoreboardCriteria criteria) {
+            this.objective.criteria = criteria;
+            return this;
+        }
+
+        @Override
+        public ScoreboardObjectiveBuilder scores(Score<?>... scores) {
+            for (Score<?> score : scores) {
+                this.objective.scores.put(score.getName(), score);
+            }
+            return this;
+        }
+
+        @Override
+        public ScoreboardObjective build() {
+            return this.objective;
+        }
+    }
+}


### PR DESCRIPTION
This brings in a scoreboard API (and eventually a finished system to interact with /scoreboard commands) to Nukkit. For the time being, this PR will mostly only cover support for scoreboards (with an API to do so) that are the equivalent of that of what can be done in vanilla Bedrock itself, however, this may also include some additions that are slightly beyond the scope of vanilla Bedrock, such as adding support for multiple criteria and teams.

I also did what other parts of the codebase have done and split up the API and implementation for the scoreboards themselves. There are some parts of the code (such as the static `builder` methods in the API classes) which directly call on the impl classes. However when Nukkit eventually does split up the API and implementation, adding in some sort of builder provider should be quite easy to do.

What's left to do:
- [x] Scoreboard API
- [ ] /scoreboard command
- [ ] Per-world scoreboards (for interacting with the scoreboard command)
- [ ] (?) Team and multiple criteria support (?)