### PR TITLE
Add support for Snow Golem mobs

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -2264,6 +2264,7 @@ public class Server {
         Entity.registerEntity("Silverfish", EntitySilverfish.class);
         Entity.registerEntity("Skeleton", EntitySkeleton.class);
         Entity.registerEntity("Slime", EntitySlime.class);
+        Entity.registerEntity("SnowGolem", EntitySnowGolem.class);
         Entity.registerEntity("Spider", EntitySpider.class);
         Entity.registerEntity("Stray", EntityStray.class);
         Entity.registerEntity("Vex", EntityVex.class);

--- a/src/main/java/cn/nukkit/entity/mob/EntitySnowGolem.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntitySnowGolem.java
@@ -11,6 +11,10 @@ public class EntitySnowGolem extends EntityMob {
         return NETWORK_ID;
     }
 
+    @Override
+    public String getName() {
+        return "Snow Golem";
+    }
 
     @Override
     public float getWidth() {

--- a/src/main/java/cn/nukkit/entity/mob/EntitySnowGolem.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntitySnowGolem.java
@@ -1,0 +1,17 @@
+package cn.nukkit.entity.mob;
+
+import cn.nukkit.level.format.FullChunk;
+import cn.nukkit.nbt.tag.CompoundTag;
+
+public class EntitySnowGolem extends EntityMob {
+    public static final int NETWORK_ID = 21;
+
+    @Override
+    public int getNetworkId() {
+        return NETWORK_ID;
+    }
+
+    public EntitySnowGolem(FullChunk chunk, CompoundTag nbt) {
+        super(chunk, nbt);
+    }
+}

--- a/src/main/java/cn/nukkit/entity/mob/EntitySnowGolem.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntitySnowGolem.java
@@ -3,7 +3,11 @@ package cn.nukkit.entity.mob;
 import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.nbt.tag.CompoundTag;
 
-public class EntitySnowGolem extends EntityMob {
+public class EntitySnowGolem extends EntityMob {    
+    public EntitySnowGolem(FullChunk chunk, CompoundTag nbt) {
+        super(chunk, nbt);
+    }
+    
     public static final int NETWORK_ID = 21;
 
     @Override
@@ -30,9 +34,5 @@ public class EntitySnowGolem extends EntityMob {
     protected void initEntity() {
         super.initEntity();
         this.setMaxHealth(4);
-    }
-
-    public EntitySnowGolem(FullChunk chunk, CompoundTag nbt) {
-        super(chunk, nbt);
     }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntitySnowGolem.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntitySnowGolem.java
@@ -11,6 +11,23 @@ public class EntitySnowGolem extends EntityMob {
         return NETWORK_ID;
     }
 
+
+    @Override
+    public float getWidth() {
+        return 0.7f;
+    }
+
+    @Override
+    public float getHeight() {
+        return 1.9f;
+    }
+
+    @Override
+    protected void initEntity() {
+        super.initEntity();
+        this.setMaxHealth(4);
+    }
+
     public EntitySnowGolem(FullChunk chunk, CompoundTag nbt) {
         super(chunk, nbt);
     }


### PR DESCRIPTION
Although the actual [Snow Golem implementation](https://github.com/Nukkit-coders/MobPlugin/blob/0832b1b3e52b0f871f60df0bc98cd88005914e92/src/main/java/nukkitcoders/mobplugin/entities/monster/walking/SnowGolem.java) lives in MobPlugin this stub class definition is necessary to ensure that invocations of `Entity.createEntity("SnowGolem", ...)` by MobPlugin actually succeed.