### PR TITLE
loadLevel() doesn't allow subfolders

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -2016,7 +2016,14 @@ public class Server {
             return false;
         }
 
-        String path = this.getDataPath() + "worlds/" + name + "/";
+        String path;
+
+        if (name.contains("/") || name.contains("\\")) {
+            path = name;
+        } else {
+            path = this.getDataPath() + "worlds/" + name + "/";
+        }
+
         if (this.getLevelByName(name) == null) {
 
             return LevelProviderManager.getProvider(path) != null;


### PR DESCRIPTION
loadLevel doesn't allow for subfolders because Server#isLevelGenerated() hardcoded the path to /worlds/name/ whereas loadLevel sets the path to the name if a / is present. 

This causes any path with subfolders (Indicated with a /) to be mismatched, causing it to not load the level due to the anvil provider giving different results for both of its getProvider() calls. Example of the issue:

**Level name:** ./worlds/otherworlds/fancyworld/

**Path to loadLevel:**  ./worlds/otherworlds/fancyworld//
**Path to isLevelGenerated:**  ./worlds/./worlds/otherworlds/fancyworld//

```java
"./worlds/otherworlds/fancyworld//"   !=   "./worlds/./worlds/otherworlds/fancyworld//"
```
