### PR TITLE
Add a potion with id = 42

### DIFF
--- a/src/main/java/cn/nukkit/potion/Potion.java
+++ b/src/main/java/cn/nukkit/potion/Potion.java
@@ -58,6 +58,7 @@ public class Potion implements Cloneable {
     public static final int TURTLE_MASTER_II = 39;
     public static final int SLOW_FALLING = 40;
     public static final int SLOW_FALLING_LONG = 41;
+    public static final int SLOWNESS_LONG_II = 42;
 
     protected static Potion[] potions;
 
@@ -106,6 +107,7 @@ public class Potion implements Cloneable {
         potions[Potion.TURTLE_MASTER_II] = new Potion(Potion.TURTLE_MASTER_II, 2);
         potions[Potion.SLOW_FALLING] = new Potion(Potion.SLOW_FALLING);
         potions[Potion.SLOW_FALLING_LONG] = new Potion(Potion.SLOW_FALLING_LONG);
+        potions[Potion.SLOWNESS_LONG_II] = new Potion(Potion.SLOWNESS_LONG_II);
     }
 
     public static Potion getPotion(int id) {

--- a/src/main/java/cn/nukkit/potion/Potion.java
+++ b/src/main/java/cn/nukkit/potion/Potion.java
@@ -107,7 +107,7 @@ public class Potion implements Cloneable {
         potions[Potion.TURTLE_MASTER_II] = new Potion(Potion.TURTLE_MASTER_II, 2);
         potions[Potion.SLOW_FALLING] = new Potion(Potion.SLOW_FALLING);
         potions[Potion.SLOW_FALLING_LONG] = new Potion(Potion.SLOW_FALLING_LONG);
-        potions[Potion.SLOWNESS_LONG_II] = new Potion(Potion.SLOWNESS_LONG_II);
+        potions[Potion.SLOWNESS_LONG_II] = new Potion(Potion.SLOWNESS_LONG_II, 2);
     }
 
     public static Potion getPotion(int id) {


### PR DESCRIPTION
I'm sure this is not the correct way to fix this issue, but while playing this afternoon, my son found a bug while using a "splash potion of slowness  slowness IV" the very last splash potion available in your creative mode inventory.  When you attempt to use this potion, the server displays the following error and stack trace: 

```
22:21:20 [ERROR] Could not tick level "world": cn.nukkit.utils.ServerException: Effect id: 42 not found, potions.length = 256
        at cn.nukkit.potion.Potion.getPotion(Potion.java:116)
        at cn.nukkit.entity.item.EntityPotion.splash(EntityPotion.java:92)
        at cn.nukkit.entity.item.EntityPotion.onUpdate(EntityPotion.java:156)
        at cn.nukkit.level.Level.doTick(Level.java:824)
        at cn.nukkit.Server.checkTickUpdates(Server.java:1066)
        at cn.nukkit.Server.tick(Server.java:1148)
        at cn.nukkit.Server.tickProcessor(Server.java:916)
        at cn.nukkit.Server.start(Server.java:893)
        at cn.nukkit.Server.<init>(Server.java:578)
        at cn.nukkit.Nukkit.main(Nukkit.java:112)
```

This seems to be because in the UI there is a spalsh potion with id 42, but there isn't one on the server. 
You can reproduce the error by scrolling to the last splash potion in creative mode and simply throwing it somewhere.   The potion will leave a UI artefact, and the server logs will spew the above message over and over again. 

This PR adds a splash potion with id 42 in order to fix the error.  

This was running last night's build on the server and minecraft pocket edition 1.16.9 though I just noticed an update available to the client.  I'm updating now (to 1.16.10) and will report back if the issue is fixed with the client update. 