### PR TITLE
Remove the donation message in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Links
 * __[Plugins](https://nukkitx.com/resources/categories/nukkit-plugins.1)__
 * __[Wiki](https://nukkitx.com/wiki/nukkit)__
 
-*Thank you for visiting our official sites. Our official websites are provided free of charge, and we do not like to place ads on the home page affecting your reading. If you like this project, please [donate to us](https://nukkitx.com/donate). All the donations will only be used for Nukkit websites and services.*
-
 Build JAR file
 -------------
 - `git clone https://github.com/CloudburstMC/Nukkit`


### PR DESCRIPTION
I recall hearing a while back that Cloudburst doesn't accept donations now that it is owned by CubeCraft, and so it would just be confusing to still have this on the readme when the link takes you to an empty page