### PR TITLE
Default value for "flags2" should be a postive integer

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/AdventureSettingsPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/AdventureSettingsPacket.java
@@ -44,7 +44,7 @@ public class AdventureSettingsPacket extends DataPacket {
 
     public long commandPermission = PERMISSION_NORMAL;
 
-    public long flags2 = -1;
+    public long flags2 = 0;
 
     public long playerPermission = Player.PERMISSION_MEMBER;
 


### PR DESCRIPTION
"flags2" is an unsigned integer which means it must be positive, and Nukkit defaults it to -1 which is invalid, but still allowed by the client for some reason.