### PR TITLE
Update BlockEntityHopper.java

### DIFF
--- a/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
@@ -156,6 +156,10 @@ public class BlockEntityHopper extends BlockEntitySpawnable implements Inventory
         }
 
         this.transferCooldown--;
+        
+        if (this.level.isBlockPowered(getBlock())) {
+        	return true;
+        }
 
         if (!this.isOnTransferCooldown()) {
             BlockEntity blockEntity = this.level.getBlockEntity(this.up());


### PR DESCRIPTION
proposed fix for #1380 Hoppers move items in the opposite direction that they should
Restores Vanilla MCBE Hopper activation(locking). 

Fixes #1380