### PR TITLE
Fixes a door-related client-prediction bug

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockDoor.java
@@ -293,6 +293,7 @@ public abstract class BlockDoor extends BlockTransparentMeta implements Faceable
         this.getLevel().getServer().getPluginManager().callEvent(event);
 
         if (event.isCancelled()) {
+            getLevel().sendBlocks(new Player[] {player}, new Block[] {this.down()}); // fixes a client-prediction bug
             return false;
         }
 


### PR DESCRIPTION
When cancelling the DoorToggleEvent or PlayerInteractEvent, if the player pressed the upper part of the door block it will remain open. Sending an block update to the block below seems to fix this issue.