### PR TITLE
Number of entries needs to be unsigned

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/CreativeContentPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/CreativeContentPacket.java
@@ -22,7 +22,7 @@ public class CreativeContentPacket extends DataPacket {
     @Override
     public void encode() {
         this.reset();
-        this.putVarInt(entries.length);
+        this.putUnsignedVarInt(entries.length);
         for (int i = 0; i < entries.length; i++) {
             this.putUnsignedVarInt(i + 1);
             this.putSlot(entries[i]);


### PR DESCRIPTION
In the CreativeContentPacket, the number of creative item entries needs to be an unsigned var int, rather than a regular var int