### PR TITLE
Add XUID to PlayerAsyncPreLoginEvent

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2187,7 +2187,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                         @Override
                         public void onRun() {
-                            e = new PlayerAsyncPreLoginEvent(username, uuid, Player.this.getAddress(), Player.this.getPort());
+                            e = new PlayerAsyncPreLoginEvent(username, uuid, loginChainData.getXUID(), Player.this.getAddress(), Player.this.getPort());
                             server.getPluginManager().callEvent(e);
                         }
 

--- a/src/main/java/cn/nukkit/event/player/PlayerAsyncPreLoginEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerAsyncPreLoginEvent.java
@@ -23,6 +23,7 @@ public class PlayerAsyncPreLoginEvent extends PlayerEvent {
 
     private final String name;
     private final UUID uuid;
+    private final String xuid;
     private final String address;
     private final int port;
 
@@ -31,9 +32,10 @@ public class PlayerAsyncPreLoginEvent extends PlayerEvent {
 
     private final List<Consumer<Server>> scheduledActions = new ArrayList<>();
 
-    public PlayerAsyncPreLoginEvent(String name, UUID uuid, String address, int port) {
+    public PlayerAsyncPreLoginEvent(String name, UUID uuid, String xuid, String address, int port) {
         this.name = name;
         this.uuid = uuid;
+        this.xuid = xuid;
         this.address = address;
         this.port = port;
     }
@@ -44,6 +46,10 @@ public class PlayerAsyncPreLoginEvent extends PlayerEvent {
 
     public UUID getUuid() {
         return uuid;
+    }
+
+    public String getXuid() {
+        return xuid;
     }
 
     public String getAddress() {


### PR DESCRIPTION
The event already contains the UUID, name, address and port - the first three of which are ways of identifying a player - so it makes sense to provide the XUID there as well (plus, i need it and others might too)