### PR TITLE
Fix level loading

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2934,7 +2934,7 @@ public class Level implements ChunkManager, Metadatable {
             int x = (int) v.x & 0x0f;
             int z = (int) v.z & 0x0f;
             if (chunk != null && chunk.isGenerated()) {
-                int y = (int) NukkitMath.clamp(v.y, 0, 254);
+                int y = (int) NukkitMath.clamp(v.y, 1, 254);
                 boolean wasAir = chunk.getBlockId(x, y - 1, z) == 0;
                 for (; y > 0; --y) {
                     int b = chunk.getFullBlock(x, y, z);


### PR DESCRIPTION
Fixes this error:
```
2020-11-17 17:48:35.407 [main] INFO  - §bVixikCZ§f[/127.0.0.1:54536] logged in with entity id 1 at (world, 128.0, 68.0409, 128.0)
2020-11-17 17:48:35.997 [main] INFO  - §eVixikCZ joined the game
2020-11-17 17:48:44.372 [main] FATAL - Unhandled exception executing command "mw tp UHC-1" in mw: java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 16
	at cn.nukkit.level.format.generic.BaseChunk.getBlockId(BaseChunk.java:130)
	at cn.nukkit.level.Level.getSafeSpawn(Level.java:2938)
	at cn.nukkit.level.Level.getSafeSpawn(Level.java:2923)
	at MultiWorld.MultiWorld.onCommand(MultiWorld.java:194)
	at cn.nukkit.command.PluginCommand.execute(PluginCommand.java:33)
	at cn.nukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:257)
	at cn.nukkit.Server.dispatchCommand(Server.java:764)
	at cn.nukkit.Player.handleDataPacket(Player.java:2791)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1510)
	at cn.nukkit.network.Network.processPackets(Network.java:273)
	at cn.nukkit.network.Network.processBatch(Network.java:256)
	at cn.nukkit.Player.handleDataPacket(Player.java:2081)
	at cn.nukkit.network.RakNetInterface.process(RakNetInterface.java:76)
	at cn.nukkit.network.Network.processInterfaces(Network.java:155)
	at cn.nukkit.Server.tick(Server.java:1153)
	at cn.nukkit.Server.tickProcessor(Server.java:933)
	at cn.nukkit.Server.start(Server.java:901)
	at cn.nukkit.Server.<init>(Server.java:582)
	at cn.nukkit.Nukkit.main(Nukkit.java:120)
```