### PR TITLE
Dropped item & xp orb performance improvement

### DIFF
--- a/src/main/java/cn/nukkit/entity/item/EntityItem.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityItem.java
@@ -2,6 +2,7 @@ package cn.nukkit.entity.item;
 
 import cn.nukkit.Player;
 import cn.nukkit.Server;
+import cn.nukkit.block.BlockID;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.entity.EntityDamageEvent;
 import cn.nukkit.event.entity.EntityDamageEvent.DamageCause;
@@ -187,12 +188,11 @@ public class EntityItem extends Entity {
                 }
             }*/
 
-            if (this.level.getBlockIdAt((int) this.x, (int) this.boundingBox.getMaxY(), (int) this.z) == 8 || this.level.getBlockIdAt((int) this.x, (int) this.boundingBox.getMaxY(), (int) this.z) == 9) { //item is fully in water or in still water
-                this.motionY -= this.getGravity() * -0.015;
-            } else if (this.isInsideOfWater()) {
-                this.motionY = this.getGravity() - 0.06; //item is going up in water, don't let it go back down too fast
-            } else {
-                this.motionY -= this.getGravity(); //item is not in water
+            int bid = level.getBlockIdAt(this.getFloorX(), this.getFloorY(), this.getFloorZ());
+            if (bid == BlockID.WATER || bid == BlockID.STILL_WATER) {
+                this.motionY = this.getGravity() - 0.06;
+            } else if (!this.isOnGround()) {
+                this.motionY -= this.getGravity();
             }
 
             if (this.checkObstruction(this.x, this.y, this.z)) {

--- a/src/main/java/cn/nukkit/entity/item/EntityItem.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityItem.java
@@ -177,7 +177,7 @@ public class EntityItem extends Entity {
                 if (this.pickupDelay < 0) {
                     this.pickupDelay = 0;
                 }
-            } else {
+            }/* else { // Done in Player#checkNearEntities
                 for (Entity entity : this.level.getNearbyEntities(this.boundingBox.grow(1, 0.5, 1), this)) {
                     if (entity instanceof Player) {
                         if (((Player) entity).pickupEntity(this, true)) {
@@ -185,7 +185,7 @@ public class EntityItem extends Entity {
                         }
                     }
                 }
-            }
+            }*/
 
             if (this.level.getBlockIdAt((int) this.x, (int) this.boundingBox.getMaxY(), (int) this.z) == 8 || this.level.getBlockIdAt((int) this.x, (int) this.boundingBox.getMaxY(), (int) this.z) == 9) { //item is fully in water or in still water
                 this.motionY -= this.getGravity() * -0.015;

--- a/src/main/java/cn/nukkit/entity/item/EntityXPOrb.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityXPOrb.java
@@ -143,7 +143,7 @@ public class EntityXPOrb extends Entity {
             }
 
             if (this.closestPlayer == null || this.closestPlayer.distanceSquared(this) > 64.0D) {
-                for (Player p : level.getPlayers().values()) {
+                for (Player p : this.getViewers().values()) {
                     if (!p.isSpectator() && p.distance(this) <= 8) {
                         this.closestPlayer = p;
                         break;

--- a/src/main/java/cn/nukkit/entity/item/EntityXPOrb.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityXPOrb.java
@@ -126,7 +126,7 @@ public class EntityXPOrb extends Entity {
                 if (this.pickupDelay < 0) {
                     this.pickupDelay = 0;
                 }
-            } else {
+            }/* else { // Done in Player#checkNearEntities
                 for (Entity entity : this.level.getCollidingEntities(this.boundingBox, this)) {
                     if (entity instanceof Player) {
                         if (((Player) entity).pickupEntity(this, false)) {
@@ -134,7 +134,7 @@ public class EntityXPOrb extends Entity {
                         }
                     }
                 }
-            }
+            }*/
 
             this.motionY -= this.getGravity();
 


### PR DESCRIPTION
This pr disables unnecessary player collision checking from dropped items and xp orbs. Idk what is the reason for this code to even exist since nearby entities for item pickups are checked by player anyways. Making every dropped item/xp orb entity not to do unnecessary entity collision checks can improve the performance a lot especially when there are many of them.

Also made xp orbs to only check the viewers instead of checking distance to all players in the world.