### PR TITLE
Implement bStats metrics

### DIFF
--- a/src/main/java/cn/nukkit/metrics/Metrics.java
+++ b/src/main/java/cn/nukkit/metrics/Metrics.java
@@ -1,0 +1,533 @@
+package cn.nukkit.metrics;
+
+import cn.nukkit.utils.MainLogger;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * bStats collects some data for plugin authors.
+ *
+ * Check out https://bStats.org/ to learn more about bStats!
+ */
+public class Metrics {
+    public static final int B_STATS_VERSION = 1;
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    // The url to which the data is sent
+    private static final String URL = "https://bStats.org/submitData/server-implementation";
+
+    // A list with all custom charts
+    private final List<CustomChart> charts = new ArrayList<>();
+
+    // The name of the server software
+    private final String name;
+
+    // The uuid of the server
+    private final String serverUUID;
+
+    // Should failed requests be logged?
+    private static boolean logFailedRequests = false;
+
+    // The logger for the failed requests
+    private static MainLogger logger;
+
+    public Metrics(String name, String serverUUID, boolean logFailedRequests, MainLogger logger) {
+        this.name = name;
+        this.serverUUID = serverUUID;
+        Metrics.logFailedRequests = logFailedRequests;
+        Metrics.logger = logger;
+
+        // Start submitting the data
+        startSubmitting();
+    }
+
+    /**
+     * Adds a custom chart.
+     *
+     * @param chart The chart to add.
+     */
+    public void addCustomChart(CustomChart chart) {
+        if (chart == null) {
+            throw new IllegalArgumentException("Chart cannot be null!");
+        }
+        charts.add(chart);
+    }
+
+    /**
+     * Starts the Scheduler which submits our data every 30 minutes.
+     */
+    private void startSubmitting() {
+        final Runnable submitTask = this::submitData;
+
+        // Many servers tend to restart at a fixed time at xx:00 which causes an uneven distribution of requests on the
+        // bStats backend. To circumvent this problem, we introduce some randomness into the initial and second delay.
+        // WARNING: You must not modify and part of this Metrics class, including the submit delay or frequency!
+        // WARNING: Modifying this code will get your plugin banned on bStats. Just don't do it!
+        long initialDelay = (long) (1000 * 60 * (3 + Math.random() * 3));
+        long secondDelay = (long) (1000 * 60 * (Math.random() * 30));
+        scheduler.schedule(submitTask, initialDelay, TimeUnit.MILLISECONDS);
+        scheduler.scheduleAtFixedRate(submitTask, initialDelay + secondDelay, 1000 * 60 * 30, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Gets the plugin specific data.
+     *
+     * @return The plugin specific data.
+     */
+    private JSONObject getPluginData() {
+        JSONObject data = new JSONObject();
+
+        data.put("pluginName", name); // Append the name of the server software
+        JSONArray customCharts = new JSONArray();
+        for (CustomChart customChart : charts) {
+            // Add the data of the custom charts
+            JSONObject chart = customChart.getRequestJsonObject();
+            if (chart == null) { // If the chart is null, we skip it
+                continue;
+            }
+            customCharts.add(chart);
+        }
+        data.put("customCharts", customCharts);
+
+        return data;
+    }
+
+    /**
+     * Gets the server specific data.
+     *
+     * @return The server specific data.
+     */
+    private JSONObject getServerData() {
+        // OS specific data
+        String osName = System.getProperty("os.name");
+        String osArch = System.getProperty("os.arch");
+        String osVersion = System.getProperty("os.version");
+        int coreCount = Runtime.getRuntime().availableProcessors();
+
+        JSONObject data = new JSONObject();
+        data.put("serverUUID", serverUUID);
+        data.put("osName", osName);
+        data.put("osArch", osArch);
+        data.put("osVersion", osVersion);
+        data.put("coreCount", coreCount);
+        return data;
+    }
+
+    /**
+     * Collects the data and sends it afterwards.
+     */
+    private void submitData() {
+        final JSONObject data = getServerData();
+
+        JSONArray pluginData = new JSONArray();
+        pluginData.add(getPluginData());
+        data.put("plugins", pluginData);
+
+        try {
+            // We are still in the Thread of the timer, so nothing get blocked :)
+            sendData(data);
+        } catch (Exception e) {
+            // Something went wrong! :(
+            if (logFailedRequests) {
+                logger.warning("Could not submit stats of " + name, e);
+            }
+        }
+    }
+
+    /**
+     * Sends the data to the bStats server.
+     *
+     * @param data The data to send.
+     * @throws Exception If the request failed.
+     */
+    private static void sendData(JSONObject data) throws Exception {
+        if (data == null) {
+            throw new IllegalArgumentException("Data cannot be null!");
+        }
+
+        HttpsURLConnection connection = (HttpsURLConnection) new java.net.URL(URL).openConnection();
+
+        // Compress the data to save bandwidth
+        byte[] compressedData = compress(data.toString());
+
+        // Add headers
+        connection.setRequestMethod("POST");
+        connection.addRequestProperty("Accept", "application/json");
+        connection.addRequestProperty("Connection", "close");
+        connection.addRequestProperty("Content-Encoding", "gzip"); // We gzip our request
+        connection.addRequestProperty("Content-Length", String.valueOf(compressedData.length));
+        connection.setRequestProperty("Content-Type", "application/json"); // We send our data in JSON format
+        connection.setRequestProperty("User-Agent", "MC-Server/" + B_STATS_VERSION);
+
+        // Send data
+        connection.setDoOutput(true);
+        DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream());
+        outputStream.write(compressedData);
+        outputStream.flush();
+        outputStream.close();
+
+        connection.getInputStream().close(); // We don't care about the response - Just send our data :)
+    }
+
+    /**
+     * Gzips the given String.
+     *
+     * @param str The string to gzip.
+     * @return The gzipped String.
+     * @throws IOException If the compression failed.
+     */
+    private static byte[] compress(final String str) throws IOException {
+        if (str == null) {
+            return null;
+        }
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        GZIPOutputStream gzip = new GZIPOutputStream(outputStream);
+        gzip.write(str.getBytes(StandardCharsets.UTF_8));
+        gzip.close();
+        return outputStream.toByteArray();
+    }
+
+    /**
+     * Represents a custom chart.
+     */
+    public static abstract class CustomChart {
+
+        // The id of the chart
+        final String chartId;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         */
+        CustomChart(String chartId) {
+            if (chartId == null || chartId.isEmpty()) {
+                throw new IllegalArgumentException("ChartId cannot be null or empty!");
+            }
+            this.chartId = chartId;
+        }
+
+        private JSONObject getRequestJsonObject() {
+            JSONObject chart = new JSONObject();
+            chart.put("chartId", chartId);
+            try {
+                JSONObject data = getChartData();
+                if (data == null) {
+                    // If the data is null we don't send the chart.
+                    return null;
+                }
+                chart.put("data", data);
+            } catch (Throwable t) {
+                return null;
+            }
+            return chart;
+        }
+
+        protected abstract JSONObject getChartData() throws Exception;
+
+    }
+
+    /**
+     * Represents a custom simple pie.
+     */
+    public static class SimplePie extends CustomChart {
+
+        private final Callable<String> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SimplePie(String chartId, Callable<String> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JSONObject getChartData() throws Exception {
+            JSONObject data = new JSONObject();
+            String value = callable.call();
+            if (value == null || value.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            data.put("value", value);
+            return data;
+        }
+    }
+
+    /**
+     * Represents a custom advanced pie.
+     */
+    public static class AdvancedPie extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public AdvancedPie(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JSONObject getChartData() throws Exception {
+            JSONObject data = new JSONObject();
+            JSONObject values = new JSONObject();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                if (entry.getValue() == 0) {
+                    continue; // Skip this invalid
+                }
+                allSkipped = false;
+                values.put(entry.getKey(), entry.getValue());
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            data.put("values", values);
+            return data;
+        }
+    }
+
+    /**
+     * Represents a custom drilldown pie.
+     */
+    public static class DrilldownPie extends CustomChart {
+
+        private final Callable<Map<String, Map<String, Integer>>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public DrilldownPie(String chartId, Callable<Map<String, Map<String, Integer>>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        public JSONObject getChartData() throws Exception {
+            JSONObject data = new JSONObject();
+            JSONObject values = new JSONObject();
+            Map<String, Map<String, Integer>> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean reallyAllSkipped = true;
+            for (Map.Entry<String, Map<String, Integer>> entryValues : map.entrySet()) {
+                JSONObject value = new JSONObject();
+                boolean allSkipped = true;
+                for (Map.Entry<String, Integer> valueEntry : map.get(entryValues.getKey()).entrySet()) {
+                    value.put(valueEntry.getKey(), valueEntry.getValue());
+                    allSkipped = false;
+                }
+                if (!allSkipped) {
+                    reallyAllSkipped = false;
+                    values.put(entryValues.getKey(), value);
+                }
+            }
+            if (reallyAllSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            data.put("values", values);
+            return data;
+        }
+    }
+
+    /**
+     * Represents a custom single line chart.
+     */
+    public static class SingleLineChart extends CustomChart {
+
+        private final Callable<Integer> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SingleLineChart(String chartId, Callable<Integer> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JSONObject getChartData() throws Exception {
+            JSONObject data = new JSONObject();
+            int value = callable.call();
+            if (value == 0) {
+                // Null = skip the chart
+                return null;
+            }
+            data.put("value", value);
+            return data;
+        }
+
+    }
+
+    /**
+     * Represents a custom multi line chart.
+     */
+    public static class MultiLineChart extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public MultiLineChart(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JSONObject getChartData() throws Exception {
+            JSONObject data = new JSONObject();
+            JSONObject values = new JSONObject();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                if (entry.getValue() == 0) {
+                    continue; // Skip this invalid
+                }
+                allSkipped = false;
+                values.put(entry.getKey(), entry.getValue());
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            data.put("values", values);
+            return data;
+        }
+
+    }
+
+    /**
+     * Represents a custom simple bar chart.
+     */
+    public static class SimpleBarChart extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SimpleBarChart(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JSONObject getChartData() throws Exception {
+            JSONObject data = new JSONObject();
+            JSONObject values = new JSONObject();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                JSONArray categoryValues = new JSONArray();
+                categoryValues.add(entry.getValue());
+                values.put(entry.getKey(), categoryValues);
+            }
+            data.put("values", values);
+            return data;
+        }
+
+    }
+
+    /**
+     * Represents a custom advanced bar chart.
+     */
+    public static class AdvancedBarChart extends CustomChart {
+
+        private final Callable<Map<String, int[]>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public AdvancedBarChart(String chartId, Callable<Map<String, int[]>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JSONObject getChartData() throws Exception {
+            JSONObject data = new JSONObject();
+            JSONObject values = new JSONObject();
+            Map<String, int[]> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, int[]> entry : map.entrySet()) {
+                if (entry.getValue().length == 0) {
+                    continue; // Skip this invalid
+                }
+                allSkipped = false;
+                JSONArray categoryValues = new JSONArray();
+                for (int categoryValue : entry.getValue()) {
+                    categoryValues.add(categoryValue);
+                }
+                values.put(entry.getKey(), categoryValues);
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            data.put("values", values);
+            return data;
+        }
+
+    }
+
+}

--- a/src/main/java/cn/nukkit/metrics/NukkitMetrics.java
+++ b/src/main/java/cn/nukkit/metrics/NukkitMetrics.java
@@ -30,7 +30,7 @@ public class NukkitMetrics {
         }
 
         if (enabled) {
-            Metrics metrics = new Metrics(server.getName(), serverUUID, logFailedRequests, server.getLogger());
+            Metrics metrics = new Metrics("Nukkit", serverUUID, logFailedRequests, server.getLogger());
 
             metrics.addCustomChart(new Metrics.SingleLineChart("players", () -> server.getOnlinePlayers().size()));
             metrics.addCustomChart(new Metrics.SimplePie("minecraft_version", server::getVersion));

--- a/src/main/java/cn/nukkit/metrics/NukkitMetrics.java
+++ b/src/main/java/cn/nukkit/metrics/NukkitMetrics.java
@@ -1,0 +1,161 @@
+package cn.nukkit.metrics;
+
+import cn.nukkit.Server;
+import cn.nukkit.utils.Config;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NukkitMetrics {
+    private final Server server;
+
+    private boolean enabled;
+    private String serverUUID;
+    private boolean logFailedRequests;
+
+    public NukkitMetrics(Server server) {
+        this.server = server;
+
+        try {
+            this.loadConfig();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        if (enabled) {
+            Metrics metrics = new Metrics(server.getName(), serverUUID, logFailedRequests, server.getLogger());
+
+            metrics.addCustomChart(new Metrics.SingleLineChart("players", () -> server.getOnlinePlayers().size()));
+            metrics.addCustomChart(new Metrics.SimplePie("minecraft_version", server::getVersion));
+            metrics.addCustomChart(new Metrics.SimplePie("nukkit_version", server::getNukkitVersion));
+            metrics.addCustomChart(new Metrics.SimplePie("xbox_auth", () -> server.getPropertyBoolean("xbox-auth") ? "Required" : "Not required"));
+
+            metrics.addCustomChart(new Metrics.AdvancedPie("player_platform", () -> {
+                Map<String, Integer> valueMap = new HashMap<>();
+
+                server.getOnlinePlayers().forEach((uuid, player) -> {
+                    String deviceOS = mapDeviceOSToString(player.getLoginChainData().getDeviceOS());
+                    if (!valueMap.containsKey(deviceOS)) {
+                        valueMap.put(deviceOS, 1);
+                    } else {
+                        valueMap.put(deviceOS, valueMap.get(deviceOS) + 1);
+                    }
+                });
+                return valueMap;
+            }));
+
+            metrics.addCustomChart(new Metrics.AdvancedPie("player_game_version", () -> {
+                Map<String, Integer> valueMap = new HashMap<>();
+
+                server.getOnlinePlayers().forEach((uuid, player) -> {
+                    String gameVersion = player.getLoginChainData().getGameVersion();
+                    if (!valueMap.containsKey(gameVersion)) {
+                        valueMap.put(gameVersion, 1);
+                    } else {
+                        valueMap.put(gameVersion, valueMap.get(gameVersion) + 1);
+                    }
+                });
+                return valueMap;
+            }));
+
+            // The following code can be attributed to the PaperMC project
+            // https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0005-Paper-Metrics.patch#L614
+            metrics.addCustomChart(new Metrics.DrilldownPie("java_version", () -> {
+                Map<String, Map<String, Integer>> map = new HashMap<>();
+                String javaVersion = System.getProperty("java.version");
+                Map<String, Integer> entry = new HashMap<>();
+                entry.put(javaVersion, 1);
+
+                // http://openjdk.java.net/jeps/223
+                // Java decided to change their versioning scheme and in doing so modified the java.version system
+                // property to return $major[.$minor][.$secuity][-ea], as opposed to 1.$major.0_$identifier
+                // we can handle pre-9 by checking if the "major" is equal to "1", otherwise, 9+
+                String majorVersion = javaVersion.split("\\.")[0];
+                String release;
+
+                int indexOf = javaVersion.lastIndexOf('.');
+
+                if (majorVersion.equals("1")) {
+                    release = "Java " + javaVersion.substring(0, indexOf);
+                } else {
+                    // of course, it really wouldn't be all that simple if they didn't add a quirk, now would it
+                    // valid strings for the major may potentially include values such as -ea to deannotate a pre release
+                    Matcher versionMatcher = Pattern.compile("\\d+").matcher(majorVersion);
+                    if (versionMatcher.find()) {
+                        majorVersion = versionMatcher.group(0);
+                    }
+                    release = "Java " + majorVersion;
+                }
+                map.put(release, entry);
+                return map;
+            }));
+        }
+    }
+
+    /**
+     * Loads the bStats configuration.
+     */
+    private void loadConfig() throws IOException {
+        File bStatsFolder = new File(server.getPluginPath(), "bStats");
+
+        if (!bStatsFolder.exists() && !bStatsFolder.mkdirs()) {
+            server.getLogger().warning("Failed to create bStats metrics directory");
+            return;
+        }
+
+        File configFile = new File(bStatsFolder, "config.yml");
+        if (!configFile.exists()) {
+            writeFile(configFile,
+                    "# bStats collects some data for plugin authors like how many servers are using their plugins.",
+                    "# To honor their work, you should not disable it.",
+                    "# This has nearly no effect on the server performance!",
+                    "# Check out https://bStats.org/ to learn more :)",
+                    "enabled: true",
+                    "serverUuid: \"" + UUID.randomUUID().toString() + "\"",
+                    "logFailedRequests: false");
+        }
+
+        Config config = new Config(configFile, Config.YAML);
+
+        // Load configuration
+        this.enabled = config.getBoolean("enabled", true);
+        this.serverUUID = config.getString("serverUuid");
+        this.logFailedRequests = config.getBoolean("logFailedRequests", false);
+    }
+
+    private void writeFile(File file, String... lines) throws IOException {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+            for (String line : lines) {
+                writer.write(line);
+                writer.newLine();
+            }
+        }
+    }
+
+    private String mapDeviceOSToString(int os) {
+        switch (os) {
+            case 1: return "Android";
+            case 2: return "iOS";
+            case 3: return "macOS";
+            case 4: return "FireOS";
+            case 5: return "Gear VR";
+            case 6: return "Hololens";
+            case 7: return "Windows 10";
+            case 8: return "Windows";
+            case 9: return "Dedicated";
+            case 10: return "PS4";
+            case 11: return "Switch";
+            case 12: return "Switch";
+            case 13: return "Xbox One";
+            case 14: return "Windows Phone";
+        }
+        return "Unknown";
+    }
+}

--- a/src/main/java/cn/nukkit/metrics/NukkitMetrics.java
+++ b/src/main/java/cn/nukkit/metrics/NukkitMetrics.java
@@ -14,6 +14,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class NukkitMetrics {
+    private static boolean metricsStarted = false;
+
     private final Server server;
 
     private boolean enabled;
@@ -22,6 +24,10 @@ public class NukkitMetrics {
 
     public NukkitMetrics(Server server) {
         this.server = server;
+
+        if (metricsStarted) {
+            return;
+        }
 
         try {
             this.loadConfig();
@@ -96,6 +102,8 @@ public class NukkitMetrics {
                 map.put(release, entry);
                 return map;
             }));
+
+            metricsStarted = true;
         }
     }
 


### PR DESCRIPTION
This PR implements metrics using https://bstats.org. It supersedes #1421. (Cloudburst version: https://github.com/CloudburstMC/Server/pull/110)

As the PaperMC project has done, a bStats directory in the plugins folder is created with a config.yml. This is in case bStats is ported to Nukkit and plugins start to include it, so that the configuration is all in one place.

The link to the bStats page: https://bstats.org/plugin/server-implementation/Nukkit/10277