### PR TITLE
Allow anvil items to be renamed

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3388,6 +3388,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         }
                     }
                     break;
+                case ProtocolInfo.FILTER_TEXT_PACKET:
+                    FilterTextPacket filterTextPacket = (FilterTextPacket) packet;
+
+                    FilterTextPacket textResponsePacket = new FilterTextPacket();
+                    textResponsePacket.text = filterTextPacket.text;
+                    textResponsePacket.fromServer = true;
+                    this.dataPacket(textResponsePacket);
+                    break;
                 default:
                     break;
             }

--- a/src/main/java/cn/nukkit/network/Network.java
+++ b/src/main/java/cn/nukkit/network/Network.java
@@ -443,5 +443,6 @@ public class Network {
         this.registerPacket(ProtocolInfo.PLAYER_ARMOR_DAMAGE_PACKET, PlayerArmorDamagePacket.class);
         this.registerPacket(ProtocolInfo.PLAYER_ENCHANT_OPTIONS_PACKET, PlayerEnchantOptionsPacket.class);
         this.registerPacket(ProtocolInfo.UPDATE_PLAYER_GAME_TYPE_PACKET, UpdatePlayerGameTypePacket.class);
+        this.registerPacket(ProtocolInfo.FILTER_TEXT_PACKET, FilterTextPacket.class);
     }
 }

--- a/src/main/java/cn/nukkit/network/protocol/FilterTextPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/FilterTextPacket.java
@@ -1,0 +1,30 @@
+package cn.nukkit.network.protocol;
+
+import lombok.ToString;
+
+@ToString
+public class FilterTextPacket extends DataPacket {
+
+    public static final byte NETWORK_ID = ProtocolInfo.FILTER_TEXT_PACKET;
+
+    public String text;
+    public boolean fromServer;
+
+    @Override
+    public byte pid() {
+        return NETWORK_ID;
+    }
+
+    @Override
+    public void decode() {
+        this.text = this.getString();
+        this.fromServer = this.getBoolean();
+    }
+
+    @Override
+    public void encode() {
+        this.reset();
+        this.putString(this.text);
+        this.putBoolean(this.fromServer);
+    }
+}

--- a/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
+++ b/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
@@ -177,6 +177,7 @@ public interface ProtocolInfo {
     byte PLAYER_FOG_PACKET = (byte) 0xa0;
     byte CORRECT_PLAYER_MOVE_PREDICTION_PACKET = (byte) 0xa1;
     byte ITEM_COMPONENT_PACKET = (byte) 0xa2;
+    byte FILTER_TEXT_PACKET = (byte) 0xa3;
 
     byte BATCH_PACKET = (byte) 0xff;
 }


### PR DESCRIPTION
This allows the client to recognize that items can be renamed.

Re-opened as the feature/1.16.100 branch was deleted.