### PR TITLE
Fix crafting in 1.16.210

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/CraftingDataPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/CraftingDataPacket.java
@@ -69,6 +69,8 @@ public class CraftingDataPacket extends DataPacket {
         this.reset();
         this.putUnsignedVarInt(entries.size());
 
+        int recipeNetworkId = 1;
+
         for (Recipe recipe : entries) {
             this.putVarInt(recipe.getType().ordinal());
             switch (recipe.getType()) {
@@ -85,7 +87,7 @@ public class CraftingDataPacket extends DataPacket {
                     this.putUUID(shapeless.getId());
                     this.putString(CRAFTING_TAG_CRAFTING_TABLE);
                     this.putVarInt(shapeless.getPriority());
-                    this.putUnsignedVarInt(0);
+                    this.putUnsignedVarInt(recipeNetworkId++);
                     break;
                 case SHAPED:
                     ShapedRecipe shaped = (ShapedRecipe) recipe;
@@ -108,7 +110,7 @@ public class CraftingDataPacket extends DataPacket {
                     this.putUUID(shaped.getId());
                     this.putString(CRAFTING_TAG_CRAFTING_TABLE);
                     this.putVarInt(shaped.getPriority());
-                    this.putUnsignedVarInt(0);
+                    this.putUnsignedVarInt(recipeNetworkId++);
                     break;
                 case FURNACE:
                 case FURNACE_DATA:
@@ -123,7 +125,7 @@ public class CraftingDataPacket extends DataPacket {
                     break;
                 case MULTI:
                     this.putUUID(((MultiRecipe) recipe).getId());
-                    this.putUnsignedVarInt(0);
+                    this.putUnsignedVarInt(recipeNetworkId++);
                     break;
             }
         }


### PR DESCRIPTION
Technical explanation: Bedrock behaves much better when each recipe in the CraftingDataPacket is assigned a network ID, even when using client-authoritative inventories.

Fixes #1798.