### PR TITLE
Fix the flow speed of lava in nether

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockLava.java
+++ b/src/main/java/cn/nukkit/block/BlockLava.java
@@ -153,7 +153,7 @@ public class BlockLava extends BlockLiquid {
 
     @Override
     public int tickRate() {
-        if (this.getLevel().getDimension() == Level.DIMENSION_NETHER) {
+        if (this.level.getDimension() == Level.DIMENSION_NETHER) {
             return 10;
         }
         return 30;

--- a/src/main/java/cn/nukkit/block/BlockLava.java
+++ b/src/main/java/cn/nukkit/block/BlockLava.java
@@ -153,6 +153,9 @@ public class BlockLava extends BlockLiquid {
 
     @Override
     public int tickRate() {
+        if (this.getLevel().getDimension() == Level.DIMENSION_NETHER) {
+            return 10;
+        }
         return 30;
     }
 


### PR DESCRIPTION
Chinese wiki is 10 ticks, but English wiki is 5 ticks
But I test in a single machine (vanilla?), I think magma flow speed is not so fast
So I used 10 tick
(Google Translate)