### PR TITLE
Update entity hurt and death animations

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1438,13 +1438,13 @@ public abstract class Entity extends Location implements Metadatable {
 
         if (!this.isAlive()) {
             ++this.deadTicks;
-            if (this.deadTicks >= 10) {
+            if (this.deadTicks >= 25) {
                 this.despawnFromAll();
                 if (!this.isPlayer) {
                     this.close();
                 }
             }
-            return this.deadTicks < 10;
+            return this.deadTicks < 25;
         }
 
         int tickDiff = currentTick - this.lastUpdate;
@@ -2171,6 +2171,15 @@ public abstract class Entity extends Location implements Metadatable {
     }
 
     public void kill() {
+        EntityAnimationEvent animationEvent = new EntityAnimationEvent(this, EntityAnimationEvent.AnimationType.DEATH);
+        this.server.getPluginManager().callEvent(animationEvent);
+        if (!animationEvent.isCancelled()) {
+            EntityEventPacket pk = new EntityEventPacket();
+            pk.eid = this.getId();
+            pk.event = EntityEventPacket.DEATH_ANIMATION;
+            Server.broadcastPacket(this.hasSpawned.values(), pk);
+        }
+
         this.health = 0;
         this.scheduleUpdate();
 

--- a/src/main/java/cn/nukkit/event/entity/EntityAnimationEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityAnimationEvent.java
@@ -1,0 +1,29 @@
+package cn.nukkit.event.entity;
+
+import cn.nukkit.entity.Entity;
+import cn.nukkit.event.Cancellable;
+import cn.nukkit.event.HandlerList;
+
+public class EntityAnimationEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+
+    private final AnimationType animationType;
+
+    public EntityAnimationEvent(Entity entity, AnimationType animation) {
+        this.entity = entity;
+        this.animationType = animation;
+    }
+
+    public AnimationType getAnimationType() {
+        return this.animationType;
+    }
+
+    public enum AnimationType {
+        HURT,
+        DEATH
+    }
+}


### PR DESCRIPTION
This pull request fixes:
- Entities are not playing the death animation if killed by using the `Entity.kill()` method.
- Entity dead ticks are too short to play the animation completely.
- Critical hit damage is not applied to the final damage.

This pull request adds:
- `cn.nukkit.event.entity.EntityAnimationEvent` which can be cancelled to stop playing hurt or death animations