### PR TITLE
EndCrystal Improvements

### DIFF
--- a/src/main/java/cn/nukkit/item/ItemEndCrystal.java
+++ b/src/main/java/cn/nukkit/item/ItemEndCrystal.java
@@ -1,18 +1,21 @@
 package cn.nukkit.item;
 
-import cn.nukkit.block.BlockObsidian;
-import cn.nukkit.block.BlockBedrock;
-import cn.nukkit.nbt.tag.CompoundTag;
-import cn.nukkit.entity.Entity;
-import java.util.Random;
-import cn.nukkit.nbt.tag.FloatTag;
-import cn.nukkit.nbt.tag.DoubleTag;
-import cn.nukkit.nbt.tag.ListTag;
-import cn.nukkit.math.BlockFace;
-import cn.nukkit.block.Block;
 import cn.nukkit.Player;
+import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockBedrock;
+import cn.nukkit.block.BlockID;
+import cn.nukkit.block.BlockObsidian;
+import cn.nukkit.entity.Entity;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.format.FullChunk;
+import cn.nukkit.math.BlockFace;
+import cn.nukkit.math.SimpleAxisAlignedBB;
+import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.nbt.tag.DoubleTag;
+import cn.nukkit.nbt.tag.FloatTag;
+import cn.nukkit.nbt.tag.ListTag;
+
+import java.util.Random;
 
 public class ItemEndCrystal extends Item {
 
@@ -35,18 +38,19 @@ public class ItemEndCrystal extends Item {
 
     @Override
     public boolean onActivate(Level level, Player player, Block block, Block target, BlockFace face, double fx, double fy, double fz) {
-        if ((!(target instanceof BlockBedrock) && !(target instanceof BlockObsidian)) || face != BlockFace.UP) return false;
+        if (!(target instanceof BlockBedrock) && !(target instanceof BlockObsidian)) return false;
         FullChunk chunk = level.getChunk((int) block.getX() >> 4, (int) block.getZ() >> 4);
+        Entity[] entities = level.getNearbyEntities(new SimpleAxisAlignedBB(target.x, target.y, target.z, target.x + 1, target.y + 2, target.z + 1));
 
-        if (chunk == null) {
+        if (chunk == null || target.up().getId() != BlockID.AIR || target.up(2).getId() != BlockID.AIR || entities.length != 0) {
             return false;
         }
 
         CompoundTag nbt = new CompoundTag()
                 .putList(new ListTag<DoubleTag>("Pos")
-                        .add(new DoubleTag("", block.getX() + 0.5))
-                        .add(new DoubleTag("", block.getY()))
-                        .add(new DoubleTag("", block.getZ() + 0.5)))
+                        .add(new DoubleTag("", target.x + 0.5))
+                        .add(new DoubleTag("", target.up().y))
+                        .add(new DoubleTag("", target.z + 0.5)))
                 .putList(new ListTag<DoubleTag>("Motion")
                         .add(new DoubleTag("", 0))
                         .add(new DoubleTag("", 0))

--- a/src/main/java/cn/nukkit/item/ItemEndCrystal.java
+++ b/src/main/java/cn/nukkit/item/ItemEndCrystal.java
@@ -41,15 +41,16 @@ public class ItemEndCrystal extends Item {
         if (!(target instanceof BlockBedrock) && !(target instanceof BlockObsidian)) return false;
         FullChunk chunk = level.getChunk((int) block.getX() >> 4, (int) block.getZ() >> 4);
         Entity[] entities = level.getNearbyEntities(new SimpleAxisAlignedBB(target.x, target.y, target.z, target.x + 1, target.y + 2, target.z + 1));
+        Block up = target.up();
 
-        if (chunk == null || target.up().getId() != BlockID.AIR || target.up(2).getId() != BlockID.AIR || entities.length != 0) {
+        if (chunk == null || up.getId() != BlockID.AIR || up.up().getId() != BlockID.AIR || entities.length != 0) {
             return false;
         }
 
         CompoundTag nbt = new CompoundTag()
                 .putList(new ListTag<DoubleTag>("Pos")
                         .add(new DoubleTag("", target.x + 0.5))
-                        .add(new DoubleTag("", target.up().y))
+                        .add(new DoubleTag("", up.y))
                         .add(new DoubleTag("", target.z + 0.5)))
                 .putList(new ListTag<DoubleTag>("Motion")
                         .add(new DoubleTag("", 0))


### PR DESCRIPTION
* Allows for end crystals to be placed using any block face.
* Only allow placement if two blocks above the bedrock or obsidian block are air & no other entities intersect the area.