### PR TITLE
Don't use empty codename in metrics

### DIFF
--- a/src/main/java/cn/nukkit/metrics/NukkitMetrics.java
+++ b/src/main/java/cn/nukkit/metrics/NukkitMetrics.java
@@ -39,7 +39,7 @@ public class NukkitMetrics {
             Metrics metrics = new Metrics("Nukkit", serverUUID, logFailedRequests, server.getLogger());
 
             metrics.addCustomChart(new Metrics.SingleLineChart("players", () -> server.getOnlinePlayers().size()));
-            metrics.addCustomChart(new Metrics.SimplePie("codename", "Nukkit"));
+            metrics.addCustomChart(new Metrics.SimplePie("codename", () -> "Nukkit"));
             metrics.addCustomChart(new Metrics.SimplePie("minecraft_version", server::getVersion));
             metrics.addCustomChart(new Metrics.SimplePie("nukkit_version", server::getNukkitVersion));
             metrics.addCustomChart(new Metrics.SimplePie("xbox_auth", () -> server.getPropertyBoolean("xbox-auth") ? "Required" : "Not required"));

--- a/src/main/java/cn/nukkit/metrics/NukkitMetrics.java
+++ b/src/main/java/cn/nukkit/metrics/NukkitMetrics.java
@@ -39,7 +39,7 @@ public class NukkitMetrics {
             Metrics metrics = new Metrics("Nukkit", serverUUID, logFailedRequests, server.getLogger());
 
             metrics.addCustomChart(new Metrics.SingleLineChart("players", () -> server.getOnlinePlayers().size()));
-            metrics.addCustomChart(new Metrics.SimplePie("codename", server::getCodename));
+            metrics.addCustomChart(new Metrics.SimplePie("codename", "Nukkit"));
             metrics.addCustomChart(new Metrics.SimplePie("minecraft_version", server::getVersion));
             metrics.addCustomChart(new Metrics.SimplePie("nukkit_version", server::getNukkitVersion));
             metrics.addCustomChart(new Metrics.SimplePie("xbox_auth", () -> server.getPropertyBoolean("xbox-auth") ? "Required" : "Not required"));


### PR DESCRIPTION
Nukkit doesn't currently have a codename and sending it as empty makes the server not appear in the "Software Name" chart making only forks with a codename appear in that chart.