### PR TITLE
Fix: Paired chests bug #1738

### DIFF
--- a/src/main/java/cn/nukkit/blockentity/BlockEntityChest.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityChest.java
@@ -55,7 +55,6 @@ public class BlockEntityChest extends BlockEntitySpawnable implements InventoryH
     @Override
     public void close() {
         if (!closed) {
-            unpair();
 
             for (Player player : new HashSet<>(this.getInventory().getViewers())) {
                 player.removeWindow(this.getInventory());
@@ -70,6 +69,9 @@ public class BlockEntityChest extends BlockEntitySpawnable implements InventoryH
 
     @Override
     public void onBreak() {
+        if (this.isPaired()) {
+			unpair();
+		}
         for (Item content : inventory.getContents().values()) {
             level.dropItem(this, content);
         }

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityChest.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityChest.java
@@ -70,8 +70,8 @@ public class BlockEntityChest extends BlockEntitySpawnable implements InventoryH
     @Override
     public void onBreak() {
         if (this.isPaired()) {
-			unpair();
-		}
+            unpair();
+        }
         for (Item content : inventory.getContents().values()) {
             level.dropItem(this, content);
         }


### PR DESCRIPTION
unpair should not be called when unloading chunks, only when breaking a paired chest.