### PR TITLE
Fix Persona skins

### DIFF
--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -268,6 +268,13 @@ public class Skin {
     }
 
     public String getPlayFabId() {
+        if (this.persona && (this.playFabId == null || this.playFabId.isEmpty())) {
+            try {
+                this.playFabId = this.skinId.split("-")[5];
+            } catch (Exception e) {
+                this.playFabId = this.fullSkinId.replace("-", "").substring(16);
+            }
+        }
         return this.playFabId;
     }
 


### PR DESCRIPTION
Persona skins with empty `PlayFabId` cannot be seen by other players.