### PR TITLE
Add PlayerFishEvent

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -5058,6 +5058,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         this.dataPacket(pk);
     }
 
+    /**
+     * Start fishing
+     * @param fishingRod fishing rod item
+     */
     public void startFishing(Item fishingRod) {
         CompoundTag nbt = new CompoundTag()
                 .putList(new ListTag<DoubleTag>("Pos")
@@ -5071,14 +5075,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 .putList(new ListTag<FloatTag>("Rotation")
                         .add(new FloatTag("", (float) yaw))
                         .add(new FloatTag("", (float) pitch)));
-        double f = 1;
+        double f = 1.1;
         EntityFishingHook fishingHook = new EntityFishingHook(chunk, nbt, this);
         fishingHook.setMotion(new Vector3(-Math.sin(Math.toRadians(yaw)) * Math.cos(Math.toRadians(pitch)) * f * f, -Math.sin(Math.toRadians(pitch)) * f * f,
                 Math.cos(Math.toRadians(yaw)) * Math.cos(Math.toRadians(pitch)) * f * f));
         ProjectileLaunchEvent ev = new ProjectileLaunchEvent(fishingHook);
         this.getServer().getPluginManager().callEvent(ev);
         if (ev.isCancelled()) {
-            fishingHook.kill();
+            fishingHook.close();
         } else {
             fishingHook.spawnToAll();
             this.fishing = fishingHook;
@@ -5086,11 +5090,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         }
     }
 
+    /**
+     * Stop fishing
+     * @param click clicked or forced
+     */
     public void stopFishing(boolean click) {
-        if (click) {
+        if (this.fishing != null && click) {
             fishing.reelLine();
         } else if (this.fishing != null) {
-            this.fishing.kill();
             this.fishing.close();
         }
 

--- a/src/main/java/cn/nukkit/entity/item/EntityFishingHook.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityFishingHook.java
@@ -10,6 +10,7 @@ import cn.nukkit.event.entity.EntityDamageByEntityEvent;
 import cn.nukkit.event.entity.EntityDamageEvent;
 import cn.nukkit.event.entity.EntityDamageEvent.DamageCause;
 import cn.nukkit.event.entity.ProjectileHitEvent;
+import cn.nukkit.event.player.PlayerFishEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.randomitem.Fishing;
 import cn.nukkit.level.MovingObjectPosition;
@@ -23,6 +24,7 @@ import cn.nukkit.network.protocol.AddEntityPacket;
 import cn.nukkit.network.protocol.EntityEventPacket;
 
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 
 /**
@@ -206,41 +208,27 @@ public class EntityFishingHook extends EntityProjectile {
 
     public void reelLine() {
         if (this.shootingEntity instanceof Player && this.caught) {
-            Item item = Fishing.getFishingResult(this.rod);
-            int experience = new Random().nextInt((3 - 1) + 1) + 1;
-            Vector3 motion;
-
-            if (this.shootingEntity != null) {
-                motion = this.shootingEntity.subtract(this).multiply(0.1);
-                motion.y += Math.sqrt(this.shootingEntity.distance(this)) * 0.08;
-            } else {
-                motion = new Vector3();
-            }
-
-            EntityItem itemEntity = new EntityItem(
-                    this.level.getChunk((int) this.x >> 4, (int) this.z >> 4, true),
-                    Entity.getDefaultNBT(new Vector3(this.x, this.getWaterHeight(), this.z), motion, new Random().nextFloat() * 360, 0).putShort("Health", 5).putCompound("Item", NBTIO.putItemHelper(item)).putShort("PickupDelay", 1));
-
-            if (this.shootingEntity != null && this.shootingEntity instanceof Player) {
-                itemEntity.setOwner(this.shootingEntity.getName());
-            }
-            itemEntity.spawnToAll();
-
             Player player = (Player) this.shootingEntity;
-            if (experience > 0) {
-                player.addExperience(experience);
+            Item item = Fishing.getFishingResult(this.rod);
+            int experience = ThreadLocalRandom.current().nextInt(3) + 1;
+            Vector3 motion = player.subtract(this).multiply(0.1);
+            motion.y += Math.sqrt(player.distance(this)) * 0.08;
+
+            PlayerFishEvent event = new PlayerFishEvent(player, this, item, experience, motion);
+            this.getServer().getPluginManager().callEvent(event);
+
+            if (!event.isCancelled()) {
+                EntityItem itemEntity = new EntityItem(
+                        this.level.getChunk((int) this.x >> 4, (int) this.z >> 4, true),
+                        Entity.getDefaultNBT(new Vector3(this.x, this.getWaterHeight(), this.z), event.getMotion(), ThreadLocalRandom.current().nextFloat() * 360, 0).putShort("Health", 5).putCompound("Item", NBTIO.putItemHelper(event.getLoot())).putShort("PickupDelay", 1));
+
+                itemEntity.setOwner(player.getName());
+                itemEntity.spawnToAll();
+
+                player.addExperience(event.getExperience());
             }
         }
-        if (this.shootingEntity instanceof Player) {
-            EntityEventPacket pk = new EntityEventPacket();
-            pk.eid = this.getId();
-            pk.event = EntityEventPacket.FISH_HOOK_TEASE;
-            Server.broadcastPacket(this.getViewers().values(), pk);
-        }
-        if (!this.closed) {
-            this.kill();
-            this.close();
-        }
+        this.close();
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/item/EntityItem.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityItem.java
@@ -1,6 +1,5 @@
 package cn.nukkit.entity.item;
 
-import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.entity.Entity;

--- a/src/main/java/cn/nukkit/event/player/PlayerFishEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerFishEvent.java
@@ -1,0 +1,63 @@
+package cn.nukkit.event.player;
+
+import cn.nukkit.Player;
+import cn.nukkit.entity.item.EntityFishingHook;
+import cn.nukkit.event.Cancellable;
+import cn.nukkit.event.HandlerList;
+import cn.nukkit.item.Item;
+import cn.nukkit.math.Vector3;
+
+/**
+ * An event that is called when player catches a fish
+ *
+ * @author PetteriM1
+ */
+public class PlayerFishEvent extends PlayerEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+
+    private final EntityFishingHook hook;
+    private Item loot;
+    private int experience;
+    private Vector3 motion;
+
+    public PlayerFishEvent(Player player, EntityFishingHook hook, Item loot, int experience, Vector3 motion) {
+        this.player = player;
+        this.hook = hook;
+        this.loot = loot;
+        this.experience = experience;
+        this.motion = motion;
+    }
+
+    public EntityFishingHook getHook() {
+        return hook;
+    }
+
+    public Item getLoot() {
+        return loot;
+    }
+
+    public void setLoot(Item loot) {
+        this.loot = loot;
+    }
+
+    public int getExperience() {
+        return experience;
+    }
+
+    public void setExperience(int experience) {
+        this.experience = experience;
+    }
+
+    public Vector3 getMotion() {
+        return motion;
+    }
+
+    public void setMotion(Vector3 motion) {
+        this.motion = motion;
+    }
+}


### PR DESCRIPTION
Add `PlayerFishEvent` that is called when player catches a fish. This event allows you to modify the dropped item (loot), the amount of experience given and the motion of the dropped item as well as let you to get the fishing hook entity.

This pr does NOT change the way starting and stopping fishing is handled. You may still use `PlayerInteractEvent` if you want to deny the usage of a fishing rod.

Fix #1692 