### PR TITLE
Add hunger when hit + Fix issue where hunger would go down despite hunger being disabled

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4171,6 +4171,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         ((Player) damager).getFoodData().updateFoodExpLevel(0.3);
                     }
                 }
+                this.getFoodData().updateFoodExpLevel(0.1);
                 EntityEventPacket pk = new EntityEventPacket();
                 pk.eid = this.id;
                 pk.event = EntityEventPacket.HURT_ANIMATION;

--- a/src/main/java/cn/nukkit/PlayerFood.java
+++ b/src/main/java/cn/nukkit/PlayerFood.java
@@ -171,12 +171,15 @@ public class PlayerFood {
     }
 
     public void updateFoodExpLevel(double use) {
-        if (!this.getPlayer().isFoodEnabled()) return;
         if (Server.getInstance().getDifficulty() == 0) return;
         if (this.getPlayer().hasEffect(Effect.SATURATION)) return;
         this.foodExpLevel += use;
         if (this.foodExpLevel > 4) {
-            this.useHunger(1);
+            if (!this.getPlayer().isFoodEnabled()) {
+                this.sendFoodLevel();
+            } else {
+                this.useHunger(1);
+            }
             this.foodExpLevel = 0;
         }
     }


### PR DESCRIPTION
Fixes #1857 
Currently, if you disable food and attack another player, their hunger will go down despite food being disabled. The server does not send any attributes to the client from what I have seen. However, this PR solves this issue by resending their hunger if food is disabled and the server decides that they need to take hunger.

Additionally, according to https://minecraft.gamepedia.com/Hunger#Exhaustion_level_increase
Food is reduced when attacked which I also implemented.