### PR TITLE
Entity fall calculation improvement

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1677,20 +1677,22 @@ public abstract class Entity extends Location implements Metadatable {
     }
 
     public void fall(float fallDistance) {
-        if ((this.isPlayer && !this.getLevel().getGameRules().getBoolean(GameRule.FALL_DAMAGE)) || this.hasEffect(Effect.SLOW_FALLING)) {
+        if (this.hasEffect(Effect.SLOW_FALLING)) {
             return;
         }
 
-        float damage = (float) Math.floor(fallDistance - 3 - (this.hasEffect(Effect.JUMP) ? this.getEffect(Effect.JUMP).getAmplifier() + 1 : 0));
-
         Block down = this.level.getBlock(this.floor().down());
 
-        if (down instanceof BlockHayBale) {
-            damage -= (damage * 0.8f);
-        }
+        if (!this.isPlayer || level.getGameRules().getBoolean(GameRule.FALL_DAMAGE)) {
+            float damage = (float) Math.floor(fallDistance - 3 - (this.hasEffect(Effect.JUMP) ? this.getEffect(Effect.JUMP).getAmplifier() + 1 : 0));
 
-        if (damage > 0) {
-            this.attack(new EntityDamageEvent(this, DamageCause.FALL, damage));
+            if (down instanceof BlockHayBale) {
+                damage -= (damage * 0.8f);
+            }
+
+            if (damage > 0) {
+                this.attack(new EntityDamageEvent(this, DamageCause.FALL, damage));
+            }
         }
 
         if (fallDistance > 0.75) {

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1677,7 +1677,7 @@ public abstract class Entity extends Location implements Metadatable {
     }
 
     public void fall(float fallDistance) {
-        if (this.hasEffect(Effect.SLOW_FALLING)) {
+        if ((this.isPlayer && !this.getLevel().getGameRules().getBoolean(GameRule.FALL_DAMAGE)) || this.hasEffect(Effect.SLOW_FALLING)) {
             return;
         }
 
@@ -1685,14 +1685,12 @@ public abstract class Entity extends Location implements Metadatable {
 
         Block down = this.level.getBlock(this.floor().down());
 
-        if(down instanceof BlockHayBale) {
+        if (down instanceof BlockHayBale) {
             damage -= (damage * 0.8f);
         }
 
         if (damage > 0) {
-            if (!this.isPlayer || level.getGameRules().getBoolean(GameRule.FALL_DAMAGE)) {
-                this.attack(new EntityDamageEvent(this, DamageCause.FALL, damage));
-            }
+            this.attack(new EntityDamageEvent(this, DamageCause.FALL, damage));
         }
 
         if (fallDistance > 0.75) {


### PR DESCRIPTION
No need for damage calculation if the entity is a player & the gamerule `falldamage` is false.