### PR TITLE
Don't overwrite runtime2Legacy states

### DIFF
--- a/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
+++ b/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
@@ -42,7 +42,9 @@ public class GlobalBlockPalette {
             int runtimeId = state.getInt("runtimeId");
             int legacyId = blockId << 6 | meta;
             legacyToRuntimeId.put(legacyId, runtimeId);
-            runtimeIdToLegacy.put(runtimeId, legacyId);
+            if (!runtimeIdToLegacy.containsKey(runtimeId)) {
+                runtimeIdToLegacy.put(runtimeId, legacyId);
+            }
         }
     }
 


### PR DESCRIPTION
Some bedrock legacy states can be mapped to same runtime id. Make sure our `runtimeIdToLegacy` map is not overwritten and correct `legacyId` can be resolved.