### PR TITLE
Fix setSprinting() in Player.java

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4865,11 +4865,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     public void setSprinting(boolean value) {
         if (isSprinting() != value) {
             super.setSprinting(value);
-
-            if(this.hasEffect(Effect.SPEED)) {
-                float movementSpeed = this.getMovementSpeed();
-                this.sendMovementSpeed(value ? movementSpeed * 1.3f : movementSpeed);
-            }
+            this.sendMovementSpeed(value ? this.movementSpeed * 1.3f : this.movementSpeed);
         }
     }
 


### PR DESCRIPTION
Fix bug: when a custom movementSpeed is set for a player via the plugin, it is reset after using the sprint.

Movement speed now works correctly, including when the player has a speed effect.