### PR TITLE
Fix crash when client sends SetPlayerGameTypePacket early

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -2199,7 +2199,7 @@ public class Server {
     }
 
     public boolean isOp(String name) {
-        return this.operators.exists(name, true);
+        return name != null && this.operators.exists(name, true);
     }
 
     public Config getWhitelist() {


### PR DESCRIPTION
Hacked client can crash the server when trying to send this packet because `player.getName()` is null. 