### PR TITLE
Update log4j to 2.17.1 to fix CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <junit.jupiter.version>5.0.0-M4</junit.jupiter.version>
         <junit.platform.version>1.0.0-M4</junit.platform.version>
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jline.version>3.9.0</jline.version>
     </properties>


### PR DESCRIPTION
Fix: https://nvd.nist.gov/vuln/detail/CVE-2021-44832