### PR TITLE
Enable Multi-Release in jar manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,7 @@
                             <addClasspath>true</addClasspath>
                             <classpathPrefix>lib/</classpathPrefix>
                             <Main-Class>cn.nukkit.Nukkit</Main-Class>
+                            <Multi-Release>true</Multi-Release>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
this will remove the warning
"WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance."
on java 9 and above