### PR TITLE
Correct Void Damage Height

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1361,7 +1361,7 @@ public abstract class Entity extends Location implements Metadatable {
 
         this.checkBlockCollision();
 
-        if (this.y <= -16 && this.isAlive()) {
+        if (this.y <= -18 && this.isAlive()) {
             if (this instanceof Player) {
                 Player player = (Player) this;
                 if (!player.isCreative()) this.attack(new EntityDamageEvent(this, DamageCause.VOID, 10));


### PR DESCRIPTION
(sorry i can only use google translate)
Tested on version 1.18.10
Overworld Void damage at -83
Hell Void damage at -19
But nukkit can't place blocks at negative height now, so I just changed it to -18