### PR TITLE
fix direct eat bug

### DIFF
--- a/src/main/java/cn/nukkit/inventory/transaction/action/DropItemAction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/action/DropItemAction.java
@@ -25,6 +25,11 @@ public class DropItemAction extends InventoryAction {
     public boolean onPreExecute(Player source) {
         PlayerDropItemEvent ev;
         source.getServer().getPluginManager().callEvent(ev = new PlayerDropItemEvent(source, this.targetItem));
+
+        if(ev.isCancelled()) {
+            source.stopAction();
+        }
+
         return !ev.isCancelled();
     }
 


### PR DESCRIPTION
Prevents that you can eat e.g. a golden apple directly, if you drop the item, the PlayerDropItemEvent is cancelled and you press right click.