### PR TITLE
Add support for WaterdogPE XUID and IP

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -174,7 +174,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     protected Vector3 teleportPosition = null;
 
     protected boolean connected = true;
-    protected final InetSocketAddress socketAddress;
+    protected final InetSocketAddress rawSocketAddress;
+    protected InetSocketAddress socketAddress;
     protected boolean removeFormat = true;
 
     protected String username;
@@ -616,6 +617,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         this.perm = new PermissibleBase(this);
         this.server = Server.getInstance();
         this.lastBreak = -1;
+        this.rawSocketAddress = socketAddress;
         this.socketAddress = socketAddress;
         this.clientID = clientID;
         this.loaderId = Level.generateChunkLoaderId(this);
@@ -676,6 +678,18 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         if (this.spawned) {
             this.server.updatePlayerListData(this.getUniqueId(), this.getId(), this.getDisplayName(), skin, this.getLoginChainData().getXUID());
         }
+    }
+
+    public String getRawAddress() {
+        return this.rawSocketAddress.getAddress().getHostAddress();
+    }
+
+    public int getRawPort() {
+        return this.rawSocketAddress.getPort();
+    }
+
+    public InetSocketAddress getRawSocketAddress() {
+        return this.rawSocketAddress;
     }
 
     public String getAddress() {
@@ -2105,6 +2119,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                     if (this.server.getOnlinePlayers().size() >= this.server.getMaxPlayers() && this.kick(PlayerKickEvent.Reason.SERVER_FULL, "disconnectionScreen.serverFull", false)) {
                         break;
+                    }
+
+                    if (this.server.getConfig("settings.waterdogpe", false) && loginChainData.getWaterdogIP() != null) {
+                        this.socketAddress = new InetSocketAddress(this.loginChainData.getWaterdogIP(), this.getRawPort());
                     }
 
                     this.randomClientId = loginPacket.clientId;

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -705,7 +705,7 @@ public class Server {
         List<InetSocketAddress> targets = new ArrayList<>();
         for (Player p : players) {
             if (p.isConnected()) {
-                targets.add(p.getSocketAddress());
+                targets.add(p.getRawSocketAddress());
             }
         }
 
@@ -1851,7 +1851,7 @@ public class Server {
     }
 
     public void removePlayer(Player player) {
-        Player toRemove = this.players.remove(player.getSocketAddress());
+        Player toRemove = this.players.remove(player.getRawSocketAddress());
         if (toRemove != null) {
             return;
         }

--- a/src/main/java/cn/nukkit/network/RakNetInterface.java
+++ b/src/main/java/cn/nukkit/network/RakNetInterface.java
@@ -132,7 +132,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
 
     @Override
     public int getNetworkLatency(Player player) {
-        RakNetServerSession session = this.raknet.getSession(player.getSocketAddress());
+        RakNetServerSession session = this.raknet.getSession(player.getRawSocketAddress());
         return session == null ? -1 : (int) session.getPing();
     }
 
@@ -143,7 +143,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
 
     @Override
     public void close(Player player, String reason) {
-        RakNetServerSession session = this.raknet.getSession(player.getSocketAddress());
+        RakNetServerSession session = this.raknet.getSession(player.getRawSocketAddress());
         if (session != null) {
             session.close();
         }
@@ -214,7 +214,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
 
     @Override
     public Integer putPacket(Player player, DataPacket packet, boolean needACK, boolean immediate) {
-        NukkitRakNetSession session = this.sessions.get(player.getSocketAddress());
+        NukkitRakNetSession session = this.sessions.get(player.getRawSocketAddress());
 
         if (session != null) {
             packet.tryEncode();

--- a/src/main/java/cn/nukkit/utils/ClientChainData.java
+++ b/src/main/java/cn/nukkit/utils/ClientChainData.java
@@ -1,5 +1,6 @@
 package cn.nukkit.utils;
 
+import cn.nukkit.Server;
 import cn.nukkit.network.protocol.LoginPacket;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -109,7 +110,11 @@ public final class ClientChainData implements LoginChainData {
 
     @Override
     public String getXUID() {
-        return xuid;
+        if (Server.getInstance().getConfig("waterdogpe", false) && Waterdog_XUID != null) {
+            return Waterdog_XUID;
+        } else {
+            return xuid;
+        }
     }
 
     private boolean xboxAuthed;
@@ -135,6 +140,16 @@ public final class ClientChainData implements LoginChainData {
     @Override
     public int getUIProfile() {
         return UIProfile;
+    }
+
+    @Override
+    public String getWaterdogXUID() {
+        return Waterdog_XUID;
+    }
+
+    @Override
+    public String getWaterdogIP() {
+        return Waterdog_IP;
     }
 
     @Override
@@ -180,6 +195,8 @@ public final class ClientChainData implements LoginChainData {
     private String languageCode;
     private int currentInputMode;
     private int defaultInputMode;
+    private String Waterdog_IP;
+    private String Waterdog_XUID;
 
     private int UIProfile;
 
@@ -215,6 +232,14 @@ public final class ClientChainData implements LoginChainData {
         if (skinToken.has("DefaultInputMode")) this.defaultInputMode = skinToken.get("DefaultInputMode").getAsInt();
         if (skinToken.has("UIProfile")) this.UIProfile = skinToken.get("UIProfile").getAsInt();
         if (skinToken.has("CapeData")) this.capeData = skinToken.get("CapeData").getAsString();
+        if (skinToken.has("Waterdog_IP")) this.Waterdog_IP = skinToken.get("Waterdog_IP").getAsString();
+        if (skinToken.has("Waterdog_XUID")) this.Waterdog_XUID = skinToken.get("Waterdog_XUID").getAsString();
+
+        boolean useWaterdog = Server.getInstance().getConfig("settings.waterdogpe", false);
+
+        if (useWaterdog && this.Waterdog_XUID != null) {
+            xboxAuthed = true;
+        }
 
         this.rawData = skinToken;
     }

--- a/src/main/java/cn/nukkit/utils/LoginChainData.java
+++ b/src/main/java/cn/nukkit/utils/LoginChainData.java
@@ -43,5 +43,9 @@ public interface LoginChainData {
 
     int getUIProfile();
 
+    String getWaterdogXUID();
+
+    String getWaterdogIP();
+
     JsonObject getRawData();
 }


### PR DESCRIPTION
This PR adds support for the `Waterdog_XUID` and `Waterdog_IP` fields in the ClientChainData when settings.waterdogpe is true. The functionality is similar to how Spigot deals with Bungeecord.

As there were changes to the `lang` folder, commit [`f6f851b`](https://github.com/funniray/Nukkit_Languages/commit/f6f851bf4f202b44a2c61eff29ff404596d7e204) would also need to be merged.