### PR TITLE
Implement native resource pack encryption support

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/ResourcePacksInfoPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/ResourcePacksInfoPacket.java
@@ -48,9 +48,9 @@ public class ResourcePacksInfoPacket extends DataPacket {
             this.putString(entry.getPackId().toString());
             this.putString(entry.getPackVersion());
             this.putLLong(entry.getPackSize());
-            this.putString(""); // encryption key
+            this.putString(entry.getEncryptionKey()); // encryption key
             this.putString(""); // sub-pack name
-            this.putString(""); // content identity
+            this.putString(!entry.getEncryptionKey().equals("") ? entry.getPackId().toString() : ""); // content identity
             this.putBoolean(false); // scripting
             this.putBoolean(false); // raytracing capable
         }

--- a/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/AbstractResourcePack.java
@@ -45,4 +45,9 @@ public abstract class AbstractResourcePack implements ResourcePack {
                 version.get(1).getAsString(),
                 version.get(2).getAsString());
     }
+
+    @Override
+    public String getEncryptionKey() {
+        return "";
+    }
 }

--- a/src/main/java/cn/nukkit/resourcepacks/ResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ResourcePack.java
@@ -14,4 +14,6 @@ public interface ResourcePack {
     byte[] getSha256();
 
     byte[] getPackChunk(int off, int len);
+
+    String getEncryptionKey();
 }

--- a/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
@@ -23,8 +23,9 @@ public class ResourcePackManager {
             try {
                 ResourcePack resourcePack = null;
 
-                if (!pack.isDirectory()) { //directory resource packs temporarily unsupported
-                    switch (Files.getFileExtension(pack.getName())) {
+                String fileExt = Files.getFileExtension(pack.getName());
+                if (!pack.isDirectory() && !fileExt.equals("key")) { //directory resource packs temporarily unsupported
+                    switch (fileExt) {
                         case "zip":
                         case "mcpack":
                             resourcePack = new ZippedResourcePack(pack);

--- a/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
@@ -41,7 +41,7 @@ public class ZippedResourcePack extends AbstractResourcePack {
             if (parentFolder == null || !parentFolder.isDirectory()) {
                 throw new IOException("Invalid resource pack path");
             }
-            File keyFile = new File(parentFolder, this.file.getName().replace(".zip", "") + ".key");
+            File keyFile = new File(parentFolder, this.file.getName() + ".key");
             if (keyFile.exists()) {
                 this.encryptionKey = new String(Files.readAllBytes(keyFile.toPath()), StandardCharsets.UTF_8);
             }

--- a/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ZippedResourcePack.java
@@ -17,6 +17,8 @@ public class ZippedResourcePack extends AbstractResourcePack {
     private File file;
     private byte[] sha256 = null;
 
+    private String encryptionKey = "";
+
     public ZippedResourcePack(File file) {
         if (!file.exists()) {
             throw new IllegalArgumentException(Server.getInstance().getLanguage()
@@ -34,6 +36,14 @@ public class ZippedResourcePack extends AbstractResourcePack {
                 this.manifest = new JsonParser()
                         .parse(new InputStreamReader(zip.getInputStream(entry), StandardCharsets.UTF_8))
                         .getAsJsonObject();
+            }
+            File parentFolder = this.file.getParentFile();
+            if (parentFolder == null || !parentFolder.isDirectory()) {
+                throw new IOException("Invalid resource pack path");
+            }
+            File keyFile = new File(parentFolder, this.file.getName().replace(".zip", "") + ".key");
+            if (keyFile.exists()) {
+                this.encryptionKey = new String(Files.readAllBytes(keyFile.toPath()), StandardCharsets.UTF_8);
             }
         } catch (IOException e) {
             Server.getInstance().getLogger().logException(e);
@@ -80,5 +90,10 @@ public class ZippedResourcePack extends AbstractResourcePack {
         }
 
         return chunk;
+    }
+
+    @Override
+    public String getEncryptionKey() {
+        return this.encryptionKey;
     }
 }


### PR DESCRIPTION
This PR implements native resource pack encryption support.

It seems now people usually encrypt their resource pack using thrid party websites such as [encryptmypack](https://encryptmypack.com)

Previously, people should use external plugins to add support for resource pack encryption such as [my plugin](https://github.com/alvin0319/RCEncryption).

Now we can enable resource pack encryption by adding `filename.key` 

This has potential BC-breaking changes.