### PR TITLE
Properly set up a docker volume and use it in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ Build image from the source,
 docker build -t nukkit .
 ```
 
-Run once to generate the `/data` volume, default settings, and choose language,
+Run once to generate the `nukkit-data` volume, default settings, and choose language,
 
 ```
-docker run -it --rm -p 19132:19132 nukkit
+docker run -it -p 19132:19132 -v nukkit-data:/data nukkit
 ```
+Docker Compose
+-------------
 
-Use [docker-compose](https://docs.docker.com/compose/overview/) to start server on port `19132` and with `./data` volume,
+Use [docker-compose](https://docs.docker.com/compose/overview/) to start server on port `19132` and with `nukkit-data` volume,
 
 ```
 docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,10 @@ services:
       - "19132:19132"
       - "19132:19132/udp"
     volumes:
-      - ./data:/data
-    stdin_open: true
-    tty: true
+      - data:/data
+    container_name: nukkit
+    restart: unless-stopped
+volumes:
+  data:
+    external: true
+    name: nukkit-data


### PR DESCRIPTION
The README.md explains how to setup a docker container with docker and docker-compose.

But the current version tells us to run a docker container with `--rm`. This will remove the volume after creation. 

If we want to create a persistent docker volume at the first start of the docker container, we need to give it a proper name (like nukkit-data, see PR) and to not set `--rm`,

In the docker-compose file we then need to tell docker-compose that the volume already exists (`external:true`) and tell the name of the already existing volume.
This way docker-compose will re-use the already existing docker volume and not create a new one.

This PR also gives the container a name in docker-compose and applies a restart policy (restart unless stopped).
