### PR TITLE
fix Network#processBatch()

### DIFF
--- a/src/main/java/cn/nukkit/network/Network.java
+++ b/src/main/java/cn/nukkit/network/Network.java
@@ -226,6 +226,7 @@ public class Network {
         List<DataPacket> packets = new ObjectArrayList<>();
         try {
             this.processBatch(packet.payload, packets, player.getNetworkSession().getCompression());
+            this.processPackets(player, packets);
         } catch (ProtocolException e) {
             player.close("", e.getMessage());
             log.error("Unable to process player packets ", e);


### PR DESCRIPTION
In fact, BatchPacket has been parsed in RakNetPlayerSession#onEncapsulated()
Modifying this method is only to prevent wrong use of plugins