### PR TITLE
removed vendor.set(JvmVendorSpec.ADOPTIUM)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,6 @@ dependencies {
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(8))
-        vendor.set(JvmVendorSpec.ADOPTIUM)
     }
 }
 


### PR DESCRIPTION
Fixes issue #2103.

There is no need to fix down the JVM vendor spec.