### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ COPY src /src/src
 COPY .git /src/.git
 COPY gradle /src/gradle
 
+RUN apt-get clean \
+    && apt-get update \
+    && apt install git -y
 RUN git submodule update --init
 RUN ./gradlew shadowJar
 


### PR DESCRIPTION
Hi guys，

  I am trying to run this project using Docker. I encountered the following error when building the image according to the ReadMe file:

<img width="841" alt="image" src="https://user-images.githubusercontent.com/47817993/227781540-113954f2-676f-4429-bccd-a8d0e02e8f48.png">

  It seems that the `git` software is not included in the `openjdk:8-jdk-slim` image, so I edited the Dockerfile and added the steps to install the `git` software.

  I noticed that these commands were removed in the previous a812b3ef0414915e9e23994661f07a0d2235336f update, I don't know why. But now, it builds successfully on my server.

