### PR TITLE
Ignore isResponse in removeWindow for now

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4948,8 +4948,11 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
     protected void removeWindow(Inventory inventory, boolean isResponse) {
         inventory.close(this);
-        if (isResponse && !this.permanentWindows.contains(this.getWindowId(inventory)))
+        // TODO: This needs a proper fix
+        // Requiring isResponse here causes issues with inventory events and an item duplication glitch
+        if (/*isResponse &&*/ !this.permanentWindows.contains(this.getWindowId(inventory))) {
             this.windows.remove(inventory);
+        }
     }
 
     public void sendAllInventories() {


### PR DESCRIPTION
Requiring isResponse causes issues with inventory events and an item duplication glitch