### PR TITLE
Fix the inability to override a commands

### DIFF
--- a/src/main/java/cn/nukkit/command/Command.java
+++ b/src/main/java/cn/nukkit/command/Command.java
@@ -211,7 +211,7 @@ public abstract class Command {
     }
 
     public boolean allowChangesFrom(CommandMap commandMap) {
-        return commandMap != null && !commandMap.equals(this.commandMap);
+        return this.commandMap == null || this.commandMap.equals(commandMap);
     }
 
     public boolean isRegistered() {


### PR DESCRIPTION
Currently, it is impossible to unregister a command using this method:
```java
public static boolean unregisterCommand(Command command){
    command.setLabel(command.getName() + "__unregistered");
    return command.unregister(Server.getInstance().getCommandMap());
}
```
`command.unregister()` returns `false` because `Command.allowChangesFrom()` returns `false`. As old code shows, a `commandMap` passed as parameter should NOT be null (which is passes fine), and it should NOT be equal to command's known command map (`this.commandMap`), this sounds as complete nonsense because command SHOULD allow changes from a `commandMap` that is equal to `this.commandMap` and vice-versa. (Vanilla commands are all registered using same `SimpleCommandMap` instance so it should always return `true` when comparing `this.commandMap` to `Server.getInstance().getCommandMap()`, right?