### PR TITLE
Docker fixes & improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Auto detect text files and perform LF normalization
 *.java text=auto eol=lf
+
+gradlew text eol=lf

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,31 +1,49 @@
-FROM arm64v8/openjdk:8-jdk-slim AS build
-WORKDIR /usr/local/src/nukkit
-COPY src /usr/local/src/nukkit/src
-COPY gradlew *.gradle.kts .gitmodules /src/
+# This Dockerfile uses Docker Multi-Stage Builds
+# See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
+# Requires Docker v17.05
+
+# Use OpenJDK JDK image for intermiediate build
+FROM --platform=linux/arm64 eclipse-temurin:8-jdk-jammy AS build
+
+# Build from source and create artifact
+WORKDIR /src
+
+COPY gradlew *.gradle.kts /src/
 COPY src /src/src
 COPY .git /src/.git
 COPY gradle /src/gradle
-RUN git submodule update --init && \
-    ./gradlew shadowJar
 
-FROM arm64v8/openjdk:8-jre-slim AS run
-LABEL maintainer="Chris Fordham <chris@fordham.id.au>"
-COPY --from=build /usr/local/src/nukkit/target/nukkit-1.0-SNAPSHOT.jar /opt/nukkit/nukkit.jar
-COPY nukkit.yml.default /etc/opt/nukkit/nukkit.yml
+RUN ./gradlew shadowJar
+
+# Use OpenJDK JRE image for runtime
+FROM --platform=linux/arm64 eclipse-temurin:8-jdk-jammy AS run
+
+# Copy artifact from build image
+COPY --from=build /src/target/nukkit-1.0-SNAPSHOT.jar /app/nukkit.jar
+
+# Create minecraft user
 RUN useradd --user-group \
             --no-create-home \
-            --home-dir /var/opt/nukkit \
+            --home-dir /data \
             --shell /usr/sbin/nologin \
-              minecraft && \
-    mkdir -p /var/opt/nukkit && \
-    chown -R minecraft /opt/nukkit /var/opt/nukkit /etc/opt/nukkit/nukkit.yml && \
-    ln -sfv /etc/opt/nukkit/nukkit.yml /var/opt/nukkit/nukkit.yml && \
-    apt-get -y update && \
-    apt-get -y install lsof && \
-    rm -rf /var/lib/apt/lists/*
-USER minecraft
-VOLUME /etc/opt/nukkit /var/opt/nukkit /opt/nukkit
-EXPOSE 19132
-WORKDIR /var/opt/nukkit
+            minecraft
+
+# Ports
+EXPOSE 19132/tcp
+EXPOSE 19132/udp
+
+RUN mkdir /data && mkdir /home/minecraft
+RUN chown -R minecraft:minecraft /app /data /home/minecraft
+
+# User and group to run as
+USER minecraft:minecraft
+
+# Volumes
+VOLUME /data /home/minecraft
+
+# Set runtime workdir
+WORKDIR /data
+
+# Run app
 ENTRYPOINT ["java"]
-CMD [ "-jar", "/opt/nukkit/nukkit.jar" ]
+CMD [ "-jar", "/app/nukkit.jar", "--language", "eng" ]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Compile Nukkit
 -------------
 - `git clone https://github.com/CloudburstMC/Nukkit`
 - `cd Nukkit`
-- `git submodule update --init`
 - `./gradlew shadowJar`
 
 The compiled JAR can be found in the `target/` directory.


### PR DESCRIPTION
- Changed gradlew line endings to fix Docker build, fixes #2157
- Use more up to date JDK Docker image
- Expose UDP port by default
- Don't ask for language on first Docker run
- No git submodules are used anymore
