### PR TITLE
Fix obsolete `version` attribute in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   nukkit:
     build: ./


### PR DESCRIPTION
This change just removes the following warning on Docker Compose:

```sh-session
$ docker compose build
WARN[0000] /Users/common/minecraft-nukkit/Nukkit/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid
```

My Docker Compose version:

```sh-session
$ docker compose version
Docker Compose version v2.30.3-desktop.1
```

See also https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313