### PR TITLE
feat(item): replace HashMap with LinkedHashMap in CreativeItems

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1386,7 +1386,7 @@ public class Item implements Cloneable, BlockID, ItemID, ProtocolInfo {
     public static class CreativeItems {
 
         private final List<CreativeItemGroup> groups = new ArrayList<>();
-        private final Map<Item, CreativeItemGroup> contents = new HashMap<>();
+        private final Map<Item, CreativeItemGroup> contents = new LinkedHashMap<>();
 
         public void clear() {
             groups.clear();


### PR DESCRIPTION
Ensure consistent iteration order of creative items by using LinkedHashMap.

by @glorydark