### PR TITLE
Fixes

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2102,7 +2102,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             server.getPluginManager().callEvent(waterFrostEvent);
                             if (!waterFrostEvent.isCancelled()) {
                                 level.setBlockAt((int) block.x, (int) block.y, (int) block.z, Block.ICE_FROSTED, 0);
-                                level.scheduleUpdate(level.getBlock(this.chunk, block.getFloorX(), block.getFloorY(), block.getFloorZ(), true), ThreadLocalRandom.current().nextInt(20, 40));
+                                level.scheduleUpdate(level.getBlock(this.chunk, (int) block.getX(), (int) block.getY(), (int) block.getZ(), true), ThreadLocalRandom.current().nextInt(20, 40));
                             }
                         }
                     }
@@ -2466,7 +2466,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     Block block;
                     while (itr.hasNext()) {
                         block = itr.next();
-                        entity = getEntityAtPosition(nearbyEntities, block.getFloorX(), block.getFloorY(), block.getFloorZ());
+                        entity = getEntityAtPosition(nearbyEntities, (int) block.getX(), (int) block.getY(), (int) block.getZ());
                         if (entity != null) {
                             break;
                         }
@@ -6210,7 +6210,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
      * @return form id to use in {@link PlayerFormRespondedEvent}
      */
     public int showFormWindow(FormWindow window, int id) {
-        if (formOpen) return 0;
+        if (formOpen) return -1;
         ModalFormRequestPacket packet = new ModalFormRequestPacket();
         packet.formId = id;
         packet.data = window.getJSONData();
@@ -6940,17 +6940,19 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                 IntArrayList itemsWithMending = new IntArrayList();
                 for (int i = 0; i < 4; i++) {
-                    if (this.inventory.getArmorItem(i).hasEnchantment(Enchantment.ID_MENDING)) {
+                    Item item = inventory.getArmorItem(i);
+                    if (item.getDamage() != 0 && item.hasEnchantment(Enchantment.ID_MENDING)) {
                         itemsWithMending.add(this.inventory.getSize() + i);
                     }
                 }
 
-                if (this.inventory.getItemInHandFast().hasEnchantment(Enchantment.ID_MENDING)) {
+                Item hand = inventory.getItemInHandFast();
+                if (hand.getDamage() != 0 && hand.hasEnchantment(Enchantment.ID_MENDING)) {
                     itemsWithMending.add(this.inventory.getHeldItemIndex());
                 }
 
                 Item offhand = this.getOffhandInventory().getItem(0);
-                if (offhand.getId() == Item.SHIELD && offhand.hasEnchantment(Enchantment.ID_MENDING)) {
+                if (offhand.getId() == Item.SHIELD && offhand.getDamage() != 0 && offhand.hasEnchantment(Enchantment.ID_MENDING)) {
                     itemsWithMending.add(-1);
                 }
 

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -972,7 +972,7 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
         return this.layer;
     }
 
-    protected static boolean canConnectToFullSolid(Block down) {
+    public static boolean canConnectToFullSolid(Block down) {
         if (down.isTransparent()) {
             switch (down.getId()) {
                 case BEACON:

--- a/src/main/java/cn/nukkit/block/BlockCaveVines.java
+++ b/src/main/java/cn/nukkit/block/BlockCaveVines.java
@@ -79,9 +79,7 @@ public class BlockCaveVines extends BlockTransparentMeta {
                 this.getLevel().useBreakOn(this, null, null, true);
                 break;
             case Level.BLOCK_UPDATE_RANDOM:
-                if (!this.tryGrowItself()) {
-                    this.tryGrow();
-                }
+                this.tryGrow();
                 break;
         }
         return type;
@@ -168,16 +166,6 @@ public class BlockCaveVines extends BlockTransparentMeta {
 
         BlockCaveVines support = (BlockCaveVines) Block.get(this.hasBerries() ? CAVE_VINES_BODY_WITH_BERRIES : CAVE_VINES, this.getDamage());
         this.getLevel().setBlock(this, support, true, true);
-        return true;
-    }
-
-    private boolean tryGrowItself() {
-        if (this.hasBerries() || ThreadLocalRandom.current().nextFloat() >= CHANCE_OF_BERRIES_ON_GROWTH) {
-            return false;
-        }
-
-        BlockCaveVines blockCaveVines = this.getStateWithBerries(this);
-        this.getLevel().setBlock(this, blockCaveVines, true, true);
         return true;
     }
 

--- a/src/main/java/cn/nukkit/block/BlockCrimsonPlanks.java
+++ b/src/main/java/cn/nukkit/block/BlockCrimsonPlanks.java
@@ -24,13 +24,13 @@ public class BlockCrimsonPlanks extends BlockSolid {
     }
 
     @Override
-    public int getBurnChance() {
-        return 0;
+    public double getHardness() {
+        return 2;
     }
 
     @Override
-    public int getBurnAbility() {
-        return 0;
+    public double getResistance() {
+        return 3;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockInfestedDeepslate.java
+++ b/src/main/java/cn/nukkit/block/BlockInfestedDeepslate.java
@@ -36,9 +36,4 @@ public class BlockInfestedDeepslate extends BlockDeepslate {
     public Item[] getDrops(Item item) {
         return new Item[0];
     }
-
-    @Override
-    public boolean canSilkTouch() {
-        return true;
-    }
 }

--- a/src/main/java/cn/nukkit/block/BlockOre.java
+++ b/src/main/java/cn/nukkit/block/BlockOre.java
@@ -14,30 +14,26 @@ public abstract class BlockOre extends BlockSolid {
 
     @Override
     public Item[] getDrops(Item item) {
-        if (!this.canHarvest(item) || item.getTier() < this.getToolTier()) {
+        if (item.isPickaxe() && item.getTier() >= this.getToolTier()) {
+            if (item.hasEnchantment(Enchantment.ID_SILK_TOUCH)) {
+                return new Item[]{this.toItem()};
+            }
+
+            int rawMaterial = this.getRawMaterial();
+            if (rawMaterial == BlockID.AIR) {
+                return super.getDrops(item);
+            }
+
+            int amount = 1;
+            int fortuneLevel = NukkitMath.clamp(item.getEnchantmentLevel(Enchantment.ID_FORTUNE_DIGGING), 0, 3);
+            if (fortuneLevel > 0) {
+                amount += ThreadLocalRandom.current().nextInt(fortuneLevel + 1);
+            }
+
+            return new Item[]{Item.get(rawMaterial, this.getRawMaterialMeta(), amount)};
+        } else {
             return new Item[0];
         }
-
-        if (item.hasEnchantment(Enchantment.ID_SILK_TOUCH)) {
-            return new Item[]{this.toItem()};
-        }
-
-        int rawMaterial = this.getRawMaterial();
-        if (rawMaterial == BlockID.AIR) {
-            return super.getDrops(item);
-        }
-
-        float multiplier = this.getDropMultiplier();
-        int amount = (int) multiplier;
-        if (amount > 1) {
-            amount = 1 + ThreadLocalRandom.current().nextInt(amount);
-        }
-        int fortuneLevel = NukkitMath.clamp(item.getEnchantmentLevel(Enchantment.ID_FORTUNE_DIGGING), 0, 3);
-        if (fortuneLevel > 0) {
-            int increase = ThreadLocalRandom.current().nextInt((int)(multiplier * fortuneLevel) + 1);
-            amount += increase;
-        }
-        return new Item[]{ Item.get(rawMaterial, this.getRawMaterialMeta(), amount) };
     }
 
     protected abstract int getRawMaterial();

--- a/src/main/java/cn/nukkit/block/BlockOreCoal.java
+++ b/src/main/java/cn/nukkit/block/BlockOreCoal.java
@@ -1,7 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemTool;
+import cn.nukkit.item.ItemID;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.utils.Utils;
 
@@ -11,26 +11,11 @@ import java.util.concurrent.ThreadLocalRandom;
  * @author MagicDroidX
  * Nukkit Project
  */
-public class BlockOreCoal extends BlockSolid {
+public class BlockOreCoal extends BlockOre {
 
     @Override
     public int getId() {
         return COAL_ORE;
-    }
-
-    @Override
-    public double getHardness() {
-        return 3;
-    }
-
-    @Override
-    public double getResistance() {
-        return 3;
-    }
-
-    @Override
-    public int getToolType() {
-        return ItemTool.TYPE_PICKAXE;
     }
 
     @Override
@@ -66,17 +51,12 @@ public class BlockOreCoal extends BlockSolid {
     }
 
     @Override
-    public int getDropExp() {
-        return Utils.rand(0, 2);
+    protected int getRawMaterial() {
+        return ItemID.COAL;
     }
 
     @Override
-    public boolean canHarvestWithHand() {
-        return false;
-    }
-    
-    @Override
-    public boolean canSilkTouch() {
-        return true;
+    public int getDropExp() {
+        return Utils.rand(0, 2);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockOreCoalDeepslate.java
+++ b/src/main/java/cn/nukkit/block/BlockOreCoalDeepslate.java
@@ -1,17 +1,10 @@
 package cn.nukkit.block;
 
-import cn.nukkit.item.ItemID;
 import cn.nukkit.utils.BlockColor;
-import cn.nukkit.utils.Utils;
 
-public class BlockOreCoalDeepslate extends BlockOre {
+public class BlockOreCoalDeepslate extends BlockOreCoal {
 
     public BlockOreCoalDeepslate() {
-    }
-
-    @Override
-    protected int getRawMaterial() {
-        return ItemID.COAL;
     }
 
     @Override
@@ -32,10 +25,5 @@ public class BlockOreCoalDeepslate extends BlockOre {
     @Override
     public BlockColor getColor() {
         return BlockColor.DEEPSLATE_GRAY;
-    }
-
-    @Override
-    public int getDropExp() {
-        return Utils.rand(0, 2);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockOreCopper.java
+++ b/src/main/java/cn/nukkit/block/BlockOreCopper.java
@@ -1,7 +1,12 @@
 package cn.nukkit.block;
 
+import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemID;
+import cn.nukkit.item.enchantment.Enchantment;
+import cn.nukkit.math.NukkitMath;
 import cn.nukkit.utils.Utils;
+
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockOreCopper extends BlockOre {
 
@@ -32,5 +37,28 @@ public class BlockOreCopper extends BlockOre {
     @Override
     public int getDropExp() {
         return Utils.rand(0, 2);
+    }
+
+    @Override
+    public Item[] getDrops(Item item) {
+        if (item.isPickaxe() && item.getTier() >= this.getToolTier()) {
+            if (item.hasEnchantment(Enchantment.ID_SILK_TOUCH)) {
+                return new Item[]{this.toItem()};
+            }
+
+            float multiplier = this.getDropMultiplier();
+            int amount = (int) multiplier;
+            if (amount > 1) {
+                amount = 2 + ThreadLocalRandom.current().nextInt(amount + 1);
+            }
+            int fortuneLevel = NukkitMath.clamp(item.getEnchantmentLevel(Enchantment.ID_FORTUNE_DIGGING), 0, 3);
+            if (fortuneLevel > 0) {
+                int increase = ThreadLocalRandom.current().nextInt((int)(multiplier * fortuneLevel) + 1);
+                amount += increase;
+            }
+            return new Item[]{ Item.get(this.getRawMaterial(), this.getRawMaterialMeta(), amount) };
+        } else {
+            return new Item[0];
+        }
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockOreDiamond.java
+++ b/src/main/java/cn/nukkit/block/BlockOreDiamond.java
@@ -1,6 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.utils.Utils;
@@ -11,26 +12,11 @@ import java.util.concurrent.ThreadLocalRandom;
  * @author MagicDroidX
  * Nukkit Project
  */
-public class BlockOreDiamond extends BlockSolid {
+public class BlockOreDiamond extends BlockOre {
 
     @Override
     public int getId() {
         return DIAMOND_ORE;
-    }
-
-    @Override
-    public double getHardness() {
-        return 3;
-    }
-
-    @Override
-    public double getResistance() {
-        return 3;
-    }
-
-    @Override
-    public int getToolType() {
-        return ItemTool.TYPE_PICKAXE;
     }
 
     @Override
@@ -66,17 +52,17 @@ public class BlockOreDiamond extends BlockSolid {
     }
 
     @Override
+    protected int getRawMaterial() {
+        return ItemID.DIAMOND;
+    }
+
+    @Override
     public int getDropExp() {
         return Utils.rand(3, 7);
     }
 
     @Override
-    public boolean canHarvestWithHand() {
-        return false;
-    }
-    
-    @Override
-    public boolean canSilkTouch() {
-        return true;
+    public int getToolTier() {
+        return ItemTool.TIER_IRON;
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockOreDiamondDeepslate.java
+++ b/src/main/java/cn/nukkit/block/BlockOreDiamondDeepslate.java
@@ -1,23 +1,10 @@
 package cn.nukkit.block;
 
-import cn.nukkit.item.ItemID;
-import cn.nukkit.item.ItemTool;
 import cn.nukkit.utils.BlockColor;
-import cn.nukkit.utils.Utils;
 
-public class BlockOreDiamondDeepslate extends BlockOre {
+public class BlockOreDiamondDeepslate extends BlockOreDiamond {
 
     public BlockOreDiamondDeepslate() {
-    }
-
-    @Override
-    protected int getRawMaterial() {
-        return ItemID.DIAMOND;
-    }
-
-    @Override
-    public int getToolTier() {
-        return ItemTool.TIER_IRON;
     }
 
     @Override
@@ -38,10 +25,5 @@ public class BlockOreDiamondDeepslate extends BlockOre {
     @Override
     public BlockColor getColor() {
         return BlockColor.DEEPSLATE_GRAY;
-    }
-
-    @Override
-    public int getDropExp() {
-        return Utils.rand(3, 7);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockOreEmerald.java
+++ b/src/main/java/cn/nukkit/block/BlockOreEmerald.java
@@ -1,6 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.utils.Utils;
@@ -11,7 +12,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * Created on 2015/12/1 by xtypr.
  * Package cn.nukkit.block in project Nukkit .
  */
-public class BlockOreEmerald extends BlockSolid {
+public class BlockOreEmerald extends BlockOre {
 
     @Override
     public String getName() {
@@ -24,23 +25,8 @@ public class BlockOreEmerald extends BlockSolid {
     }
 
     @Override
-    public int getToolType() {
-        return ItemTool.TYPE_PICKAXE;
-    }
-
-    @Override
-    public double getHardness() {
-        return 3;
-    }
-
-    @Override
-    public double getResistance() {
-        return 3;
-    }
-
-    @Override
     public Item[] getDrops(Item item) {
-        if (item.isPickaxe() && item.getTier() >= ItemTool.TIER_IRON) {
+        if (item.isPickaxe() && item.getTier() >= this.getToolTier()) {
             if (item.hasEnchantment(Enchantment.ID_SILK_TOUCH)) {
                 return new Item[]{this.toItem()};
             }
@@ -66,17 +52,17 @@ public class BlockOreEmerald extends BlockSolid {
     }
 
     @Override
+    protected int getRawMaterial() {
+        return ItemID.EMERALD;
+    }
+
+    @Override
     public int getDropExp() {
         return Utils.rand(3, 7);
     }
 
     @Override
-    public boolean canHarvestWithHand() {
-        return false;
-    }
-    
-    @Override
-    public boolean canSilkTouch() {
-        return true;
+    public int getToolTier() {
+        return ItemTool.TIER_IRON;
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockOreEmeraldDeepslate.java
+++ b/src/main/java/cn/nukkit/block/BlockOreEmeraldDeepslate.java
@@ -1,23 +1,10 @@
 package cn.nukkit.block;
 
-import cn.nukkit.item.ItemID;
-import cn.nukkit.item.ItemTool;
 import cn.nukkit.utils.BlockColor;
-import cn.nukkit.utils.Utils;
 
-public class BlockOreEmeraldDeepslate extends BlockOre {
+public class BlockOreEmeraldDeepslate extends BlockOreEmerald {
 
     public BlockOreEmeraldDeepslate() {
-    }
-
-    @Override
-    protected int getRawMaterial() {
-        return ItemID.EMERALD;
-    }
-
-    @Override
-    public int getToolTier() {
-        return ItemTool.TIER_IRON;
     }
 
     @Override
@@ -38,10 +25,5 @@ public class BlockOreEmeraldDeepslate extends BlockOre {
     @Override
     public BlockColor getColor() {
         return BlockColor.DEEPSLATE_GRAY;
-    }
-
-    @Override
-    public int getDropExp() {
-        return Utils.rand(3, 7);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockOreGoldDeepslate.java
+++ b/src/main/java/cn/nukkit/block/BlockOreGoldDeepslate.java
@@ -1,10 +1,9 @@
 package cn.nukkit.block;
 
 import cn.nukkit.item.ItemID;
-import cn.nukkit.item.ItemTool;
 import cn.nukkit.utils.BlockColor;
 
-public class BlockOreGoldDeepslate extends BlockOre {
+public class BlockOreGoldDeepslate extends BlockOreGold {
 
     public BlockOreGoldDeepslate() {
     }
@@ -12,11 +11,6 @@ public class BlockOreGoldDeepslate extends BlockOre {
     @Override
     protected int getRawMaterial() {
         return ItemID.RAW_GOLD;
-    }
-
-    @Override
-    public int getToolTier() {
-        return ItemTool.TIER_IRON;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockOreGoldNether.java
+++ b/src/main/java/cn/nukkit/block/BlockOreGoldNether.java
@@ -1,32 +1,17 @@
 package cn.nukkit.block;
 
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemTool;
+import cn.nukkit.item.ItemID;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.utils.BlockColor;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-public class BlockOreGoldNether extends BlockSolid {
+public class BlockOreGoldNether extends BlockOre {
 
     @Override
     public int getId() {
         return NETHER_GOLD_ORE;
-    }
-
-    @Override
-    public double getHardness() {
-        return 3;
-    }
-
-    @Override
-    public double getResistance() {
-        return 3;
-    }
-
-    @Override
-    public int getToolType() {
-        return ItemTool.TYPE_PICKAXE;
     }
 
     @Override
@@ -74,13 +59,8 @@ public class BlockOreGoldNether extends BlockSolid {
     }
 
     @Override
-    public boolean canHarvestWithHand() {
-        return false;
-    }
-
-    @Override
-    public boolean canSilkTouch() {
-        return true;
+    protected int getRawMaterial() {
+        return ItemID.GOLD_NUGGET;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockOreIronDeepslate.java
+++ b/src/main/java/cn/nukkit/block/BlockOreIronDeepslate.java
@@ -3,7 +3,7 @@ package cn.nukkit.block;
 import cn.nukkit.item.ItemID;
 import cn.nukkit.utils.BlockColor;
 
-public class BlockOreIronDeepslate extends BlockOre {
+public class BlockOreIronDeepslate extends BlockOreIron {
 
     public BlockOreIronDeepslate() {
     }

--- a/src/main/java/cn/nukkit/block/BlockOreLapis.java
+++ b/src/main/java/cn/nukkit/block/BlockOreLapis.java
@@ -1,7 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemTool;
+import cn.nukkit.item.ItemID;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.utils.Utils;
 
@@ -11,26 +11,11 @@ import java.util.concurrent.ThreadLocalRandom;
  * @author MagicDroidX
  * Nukkit Project
  */
-public class BlockOreLapis extends BlockSolid {
+public class BlockOreLapis extends BlockOre {
 
     @Override
     public int getId() {
         return LAPIS_ORE;
-    }
-
-    @Override
-    public double getHardness() {
-        return 3;
-    }
-
-    @Override
-    public double getResistance() {
-        return 3;
-    }
-
-    @Override
-    public int getToolType() {
-        return ItemTool.TYPE_PICKAXE;
     }
 
     @Override
@@ -40,7 +25,7 @@ public class BlockOreLapis extends BlockSolid {
 
     @Override
     public Item[] getDrops(Item item) {
-        if (item.isPickaxe() && item.getTier() >= ItemTool.TIER_STONE) {
+        if (item.isPickaxe() && item.getTier() >= this.getToolTier()) {
             if (item.hasEnchantment(Enchantment.ID_SILK_TOUCH)) {
                 return new Item[]{this.toItem()};
             }
@@ -66,17 +51,12 @@ public class BlockOreLapis extends BlockSolid {
     }
 
     @Override
-    public int getDropExp() {
-        return Utils.rand(2, 5);
+    protected int getRawMaterial() {
+        return ItemID.DYE;
     }
 
     @Override
-    public boolean canHarvestWithHand() {
-        return false;
-    }
-    
-    @Override
-    public boolean canSilkTouch() {
-        return true;
+    public int getDropExp() {
+        return Utils.rand(2, 5);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockOreLapisDeepslate.java
+++ b/src/main/java/cn/nukkit/block/BlockOreLapisDeepslate.java
@@ -1,17 +1,11 @@
 package cn.nukkit.block;
 
 import cn.nukkit.item.ItemDye;
-import cn.nukkit.item.ItemID;
 import cn.nukkit.utils.BlockColor;
 
-public class BlockOreLapisDeepslate extends BlockOre {
+public class BlockOreLapisDeepslate extends BlockOreLapis {
 
     public BlockOreLapisDeepslate() {
-    }
-
-    @Override
-    protected int getRawMaterial() {
-        return ItemID.DYE;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockOreQuartz.java
+++ b/src/main/java/cn/nukkit/block/BlockOreQuartz.java
@@ -1,7 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemTool;
+import cn.nukkit.item.ItemID;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.utils.Utils;
 
@@ -11,7 +11,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * Created on 2015/12/26 by xtypr.
  * Package cn.nukkit.block in project Nukkit .
  */
-public class BlockOreQuartz extends BlockSolid {
+public class BlockOreQuartz extends BlockOre {
 
     @Override
     public String getName() {
@@ -21,21 +21,6 @@ public class BlockOreQuartz extends BlockSolid {
     @Override
     public int getId() {
         return QUARTZ_ORE;
-    }
-
-    @Override
-    public double getHardness() {
-        return 3;
-    }
-
-    @Override
-    public double getResistance() {
-        return 3;
-    }
-
-    @Override
-    public int getToolType() {
-        return ItemTool.TYPE_PICKAXE;
     }
 
     @Override
@@ -66,17 +51,12 @@ public class BlockOreQuartz extends BlockSolid {
     }
 
     @Override
+    protected int getRawMaterial() {
+        return ItemID.QUARTZ;
+    }
+
+    @Override
     public int getDropExp() {
         return Utils.rand(1, 5);
-    }
-
-    @Override
-    public boolean canHarvestWithHand() {
-        return false;
-    }
-
-    @Override
-    public boolean canSilkTouch() {
-        return true;
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockOreRedstone.java
+++ b/src/main/java/cn/nukkit/block/BlockOreRedstone.java
@@ -1,6 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemID;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.level.Level;
@@ -12,26 +13,11 @@ import java.util.concurrent.ThreadLocalRandom;
  * @author MagicDroidX
  * Nukkit Project
  */
-public class BlockOreRedstone extends BlockSolid {
+public class BlockOreRedstone extends BlockOre {
 
     @Override
     public int getId() {
         return REDSTONE_ORE;
-    }
-
-    @Override
-    public double getHardness() {
-        return 3;
-    }
-
-    @Override
-    public double getResistance() {
-        return 3;
-    }
-
-    @Override
-    public int getToolType() {
-        return ItemTool.TYPE_PICKAXE;
     }
 
     @Override
@@ -41,7 +27,7 @@ public class BlockOreRedstone extends BlockSolid {
 
     @Override
     public Item[] getDrops(Item item) {
-        if (item.isPickaxe() && item.getTier() >= ItemTool.TIER_IRON) {
+        if (item.isPickaxe() && item.getTier() >= this.getToolTier()) {
             if (item.hasEnchantment(Enchantment.ID_SILK_TOUCH)) {
                 return new Item[]{this.toItem()};
             }
@@ -62,6 +48,11 @@ public class BlockOreRedstone extends BlockSolid {
     }
 
     @Override
+    protected int getRawMaterial() {
+        return ItemID.REDSTONE_DUST;
+    }
+
+    @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_TOUCH) {
             this.getLevel().setBlock(this, Block.get(GLOWING_REDSTONE_ORE), false, false);
@@ -79,12 +70,7 @@ public class BlockOreRedstone extends BlockSolid {
     }
 
     @Override
-    public boolean canHarvestWithHand() {
-        return false;
-    }
-
-    @Override
-    public boolean canSilkTouch() {
-        return true;
+    public int getToolTier() {
+        return ItemTool.TIER_IRON;
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockOreRedstoneDeepslate.java
+++ b/src/main/java/cn/nukkit/block/BlockOreRedstoneDeepslate.java
@@ -1,11 +1,9 @@
 package cn.nukkit.block;
 
-import cn.nukkit.item.ItemID;
-import cn.nukkit.item.ItemTool;
 import cn.nukkit.level.Level;
 import cn.nukkit.utils.BlockColor;
 
-public class BlockOreRedstoneDeepslate extends BlockOre {
+public class BlockOreRedstoneDeepslate extends BlockOreRedstone {
 
     public BlockOreRedstoneDeepslate() {
     }
@@ -19,16 +17,6 @@ public class BlockOreRedstoneDeepslate extends BlockOre {
             return Level.BLOCK_UPDATE_WEAK;
         }
         return 0;
-    }
-
-    @Override
-    protected int getRawMaterial() {
-        return ItemID.REDSTONE_DUST;
-    }
-
-    @Override
-    public int getToolTier() {
-        return ItemTool.TIER_IRON;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockOreRedstoneDeepslateGlowing.java
+++ b/src/main/java/cn/nukkit/block/BlockOreRedstoneDeepslateGlowing.java
@@ -27,7 +27,7 @@ public class BlockOreRedstoneDeepslateGlowing extends BlockOreRedstoneDeepslate 
 
     @Override
     public Item toItem() {
-        return new ItemBlock(Block.get(REDSTONE_ORE));
+        return new ItemBlock(Block.get(DEEPSLATE_REDSTONE_ORE));
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockSkull.java
+++ b/src/main/java/cn/nukkit/block/BlockSkull.java
@@ -78,9 +78,9 @@ public class BlockSkull extends BlockTransparentMeta implements Faceable {
         CompoundTag nbt = new CompoundTag()
                 .putString("id", BlockEntity.SKULL)
                 .putByte("SkullType", item.getDamage())
-                .putInt("x", block.getFloorX())
-                .putInt("y", block.getFloorY())
-                .putInt("z", block.getFloorZ())
+                .putInt("x", (int) block.getX())
+                .putInt("y", (int) block.getY())
+                .putInt("z", (int) block.getZ())
                 .putByte("Rot", (int) Math.floor((player.yaw * 16 / 360) + 0.5) & 0x0f);
         if (item.hasCustomBlockData()) {
             for (Tag aTag : item.getCustomBlockData().getAllTags()) {

--- a/src/main/java/cn/nukkit/block/BlockTurtleEgg.java
+++ b/src/main/java/cn/nukkit/block/BlockTurtleEgg.java
@@ -88,9 +88,12 @@ public class BlockTurtleEgg extends BlockTransparentMeta {
 
     @Override
     public boolean place(Item item, Block block, Block target, BlockFace face, double fx, double fy, double fz, Player player) {
-        if (target instanceof BlockTurtleEgg && this.getDamage() < 3) {
-            this.setDamage(this.getDamage() + 1);
-            return this.getLevel().setBlock(target, this, true, true);
+        if (target instanceof BlockTurtleEgg) {
+            if (target.getDamage() < 3) {
+                this.setDamage(target.getDamage() + 1);
+                return this.getLevel().setBlock(target, this, true, true);
+            }
+            return false;
         }
         if (!canStayOnFullSolid(this.down())) {
             return false;

--- a/src/main/java/cn/nukkit/block/BlockWarpedPlanks.java
+++ b/src/main/java/cn/nukkit/block/BlockWarpedPlanks.java
@@ -42,14 +42,4 @@ public class BlockWarpedPlanks extends BlockSolid {
     public BlockColor getColor() {
         return BlockColor.WARPED_STEM_BLOCK_COLOR;
     }
-
-    @Override
-    public int getBurnChance() {
-        return 0;
-    }
-
-    @Override
-    public int getBurnAbility() {
-        return 0;
-    }
 }

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1915,10 +1915,8 @@ public abstract class Entity extends Location implements Metadatable {
     }
 
     public void setAbsorption(float absorption) {
-        if (absorption != this.absorption) {
-            this.absorption = absorption;
-            if (this instanceof Player) ((Player) this).setAttribute(Attribute.getAttribute(Attribute.ABSORPTION).setValue(absorption));
-        }
+        this.absorption = absorption;
+        if (this instanceof Player) ((Player) this).setAttribute(Attribute.getAttribute(Attribute.ABSORPTION).setValue(absorption));
     }
 
     public BlockFace getDirection() {

--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -53,7 +53,7 @@ public class Skin {
     private String skinColor = "#0";
     private String armSize = "wide";
     private boolean trusted = true;
-    private String geometryDataEngineVersion = "";
+    private String geometryDataEngineVersion = "0.0.0";
     private boolean overridingPlayerAppearance = true;
 
     public boolean isValid() {

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
@@ -171,8 +171,8 @@ public abstract class EntityMinecartAbstract extends EntityVehicle implements En
             if (Rail.isRailBlock(block)) {
                 processMovement(dx, dy, dz, (BlockRail) block);
                 // Activate the minecart/TNT
-                if (block instanceof BlockRailActivator && ((BlockRailActivator) block).isActive()) {
-                    activate(dx, dy, dz, (block.getDamage() & 0x8) != 0);
+                if (block instanceof BlockRailActivator) {
+                    activate(dx, dy, dz, ((BlockRailActivator) block).isActive());
                 }
             } else {
                 setFalling();

--- a/src/main/java/cn/nukkit/entity/item/EntityPainting.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityPainting.java
@@ -59,7 +59,7 @@ public class EntityPainting extends EntityHanging {
         addPainting.y = (float) this.y;
         addPainting.z = (float) this.z;
         addPainting.direction = this.getDirection().getHorizontalIndex();
-        addPainting.title = this.namedTag.getString("Motive");
+        addPainting.title = this.motive.title;
         return addPainting;
     }
 
@@ -91,7 +91,7 @@ public class EntityPainting extends EntityHanging {
     }
 
     public Motive getMotive() {
-        return Motive.BY_NAME.get(namedTag.getString("Motive"));
+        return this.motive;
     }
 
     public enum Motive {
@@ -120,7 +120,27 @@ public class EntityPainting extends EntityHanging {
         DONKEY_KONG("DonkeyKong", 4, 3),
         POINTER("Pointer", 4, 4),
         PIG_SCENE("Pigscene", 4, 4),
-        BURNING_SKULL("BurningSkull", 4, 4);
+        BURNING_SKULL("BurningSkull", 4, 4),
+        MEDITATIVE("meditative", 1, 1),
+        PRAIRIE_RIDE("prairie_ride", 1, 2),
+        BAROQUE("baroque", 2, 2),
+        HUMBLE("humble", 2, 2),
+        UNPACKED("unpacked", 4, 4),
+        BOUQUET("bouquet", 3, 3),
+        CAVEBIRD("cavebird", 3, 3),
+        COTAN("cotan", 3, 3),
+        ENDBOSS("endboss", 3, 3),
+        FERN("fern", 3, 3),
+        OWLEMONS("owlemons", 3, 3),
+        SUNFLOWERS("sunflowers", 3, 3),
+        TIDES("tides", 3, 3),
+        BACKYARD("backyard", 3, 4),
+        POND("pond", 3, 4),
+        CHANGING("changing", 4, 2),
+        FINDING("finding", 4, 2),
+        LOWMIST("lowmist", 4, 2),
+        PASSAGE("passage", 4, 2),
+        ORB("orb", 4, 4);
 
         public final String title;
         public final int width;

--- a/src/main/java/cn/nukkit/inventory/Fuel.java
+++ b/src/main/java/cn/nukkit/inventory/Fuel.java
@@ -75,6 +75,7 @@ public abstract class Fuel {
         duration.put(Item.JUNGLE_DOOR, (short) 200);
         duration.put(Item.ACACIA_DOOR, (short) 200);
         duration.put(Item.DARK_OAK_DOOR, (short) 200);
+        duration.put(Item.MANGROVE_DOOR, (short) 200);
         duration.put(Item.BANNER, (short) 300);
         duration.put(Item.CROSSBOW, (short) 200);
         duration.put(Item.DEAD_BUSH, (short) 100);
@@ -84,6 +85,7 @@ public abstract class Fuel {
         duration.put(Item.SPRUCE_SIGN, (short) 200);
         duration.put(Item.DARKOAK_SIGN, (short) 200);
         duration.put(Item.JUNGLE_SIGN, (short) 200);
+        duration.put(Item.MANGROVE_SIGN, (short) 200);
 
         /* New blocks use negative IDs in their item form */
         duration.put(255 - BlockID.DRIED_KELP_BLOCK, (short) 4000);
@@ -105,22 +107,33 @@ public abstract class Fuel {
         duration.put(255 - BlockID.STRIPPED_JUNGLE_LOG, (short) 300);
         duration.put(255 - BlockID.STRIPPED_ACACIA_LOG, (short) 300);
         duration.put(255 - BlockID.STRIPPED_DARK_OAK_LOG, (short) 300);
+        duration.put(255 - BlockID.STRIPPED_MANGROVE_LOG, (short) 300);
         duration.put(255 - BlockID.SPRUCE_TRAPDOOR, (short) 300);
         duration.put(255 - BlockID.BIRCH_TRAPDOOR, (short) 300);
         duration.put(255 - BlockID.JUNGLE_TRAPDOOR, (short) 300);
         duration.put(255 - BlockID.ACACIA_TRAPDOOR, (short) 300);
         duration.put(255 - BlockID.DARK_OAK_TRAPDOOR, (short) 300);
+        duration.put(255 - BlockID.MANGROVE_TRAPDOOR, (short) 300);
         duration.put(255 - BlockID.SPRUCE_BUTTON, (short) 300);
         duration.put(255 - BlockID.BIRCH_BUTTON, (short) 300);
         duration.put(255 - BlockID.JUNGLE_BUTTON, (short) 300);
         duration.put(255 - BlockID.ACACIA_BUTTON, (short) 300);
         duration.put(255 - BlockID.DARK_OAK_BUTTON, (short) 300);
+        duration.put(255 - BlockID.MANGROVE_BUTTON, (short) 300);
         duration.put(255 - BlockID.SPRUCE_PRESSURE_PLATE, (short) 300);
         duration.put(255 - BlockID.BIRCH_PRESSURE_PLATE, (short) 300);
         duration.put(255 - BlockID.JUNGLE_PRESSURE_PLATE, (short) 300);
         duration.put(255 - BlockID.ACACIA_PRESSURE_PLATE, (short) 300);
         duration.put(255 - BlockID.DARK_OAK_PRESSURE_PLATE, (short) 300);
+        duration.put(255 - BlockID.MANGROVE_PRESSURE_PLATE, (short) 300);
         duration.put(255 - BlockID.AZALEA, (short) 100);
         duration.put(255 - BlockID.FLOWERING_AZALEA, (short) 100);
+        duration.put(255 - BlockID.MANGROVE_WOOD, (short) 300);
+        duration.put(255 - BlockID.MANGROVE_PLANKS, (short) 300);
+        duration.put(255 - BlockID.MANGROVE_FENCE, (short) 300);
+        duration.put(255 - BlockID.MANGROVE_FENCE_GATE, (short) 300);
+        duration.put(255 - BlockID.MANGROVE_STAIRS, (short) 300);
+        duration.put(255 - BlockID.MANGROVE_SLAB, (short) 300);
+        duration.put(255 - BlockID.MANGROVE_DOUBLE_SLAB, (short) 300);
     }
 }

--- a/src/main/java/cn/nukkit/level/ChunkManager.java
+++ b/src/main/java/cn/nukkit/level/ChunkManager.java
@@ -56,4 +56,12 @@ public interface ChunkManager {
     void setChunk(int chunkX, int chunkZ, BaseFullChunk chunk);
 
     long getSeed();
+
+    default int getMinBlockY() {
+        return 0;
+    }
+
+    default int getMaxBlockY() {
+        return 255;
+    }
 }

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1157,6 +1157,8 @@ public class Level implements ChunkManager, Metadatable, GeneratorTaskFactory {
         int blockTest = 0;
 
         if (!chunkTickList.isEmpty()) {
+            int tickSpeed = gameRules.getInteger(GameRule.RANDOM_TICK_SPEED);
+
             ObjectIterator<Long2IntMap.Entry> iter = chunkTickList.long2IntEntrySet().iterator();
             while (iter.hasNext()) {
                 Long2IntMap.Entry entry = iter.next();
@@ -1192,7 +1194,7 @@ public class Level implements ChunkManager, Metadatable, GeneratorTaskFactory {
                     for (ChunkSection section : ((Chunk) chunk).getSections()) {
                         if (!(section instanceof EmptyChunkSection)) {
                             int Y = section.getY();
-                            for (int i = 0; i < gameRules.getInteger(GameRule.RANDOM_TICK_SPEED); ++i) {
+                            for (int i = 0; i < tickSpeed; ++i) {
                                 int n = ThreadLocalRandom.current().nextInt();
                                 int x = n & 0xF;
                                 int z = n >> 8 & 0xF;
@@ -1210,7 +1212,7 @@ public class Level implements ChunkManager, Metadatable, GeneratorTaskFactory {
                 } else {
                     for (int Y = 0; Y < 8 && (Y < 3 || blockTest != 0); ++Y) {
                         blockTest = 0;
-                        for (int i = 0; i < gameRules.getInteger(GameRule.RANDOM_TICK_SPEED); ++i) {
+                        for (int i = 0; i < tickSpeed; ++i) {
                             int n = ThreadLocalRandom.current().nextInt();
                             int x = n & 0xF;
                             int z = n >> 8 & 0xF;

--- a/src/main/java/cn/nukkit/level/ListChunkManager.java
+++ b/src/main/java/cn/nukkit/level/ListChunkManager.java
@@ -94,4 +94,14 @@ public class ListChunkManager implements ChunkManager {
     public List<Block> getBlocks() {
         return this.blocks;
     }
+
+    @Override
+    public int getMinBlockY() {
+        return parent instanceof Level ? parent.getMinBlockY() : 0;
+    }
+
+    @Override
+    public int getMaxBlockY() {
+        return parent instanceof Level ? parent.getMaxBlockY() : 255;
+    }
 }

--- a/src/main/java/cn/nukkit/level/generator/SimpleChunkManager.java
+++ b/src/main/java/cn/nukkit/level/generator/SimpleChunkManager.java
@@ -116,7 +116,4 @@ public abstract class SimpleChunkManager implements ChunkManager {
     public void cleanChunks(long seed) {
         this.seed = seed;
     }
-
-    public abstract int getMinBlockY();
-    public abstract int getMaxBlockY();
 }

--- a/src/main/java/cn/nukkit/level/generator/SingleChunkManager.java
+++ b/src/main/java/cn/nukkit/level/generator/SingleChunkManager.java
@@ -42,14 +42,4 @@ public class SingleChunkManager extends SimpleChunkManager {
         CX = Integer.MAX_VALUE;
         CZ = Integer.MAX_VALUE;
     }
-
-    @Override
-    public int getMinBlockY() {
-        return 0;
-    }
-
-    @Override
-    public int getMaxBlockY() {
-        return 255;
-    }
 }

--- a/src/main/java/cn/nukkit/level/generator/object/ObjectTallGrass.java
+++ b/src/main/java/cn/nukkit/level/generator/object/ObjectTallGrass.java
@@ -3,7 +3,6 @@ package cn.nukkit.level.generator.object;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockLayer;
 import cn.nukkit.level.ChunkManager;
-import cn.nukkit.level.Level;
 import cn.nukkit.math.NukkitRandom;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.utils.Utils;
@@ -22,8 +21,8 @@ public class ObjectTallGrass {
     }
 
     public static void growGrass(ChunkManager level, Vector3 pos) {
-        int maxBlockY = level instanceof Level ? ((Level) level).getMaxBlockY() : 255;
-        int minBlockY = level instanceof Level ? ((Level) level).getMinBlockY() : 0;
+        int maxBlockY = level.getMaxBlockY();
+        int minBlockY = level.getMinBlockY();
 
         for (int i = 0; i < 128; ++i) {
             int num = 0;
@@ -66,8 +65,8 @@ public class ObjectTallGrass {
     }
 
     public static void growSeagrass(ChunkManager level, Vector3 pos) {
-        int maxBlockY = level instanceof Level ? ((Level) level).getMaxBlockY() : 255;
-        int minBlockY = level instanceof Level ? ((Level) level).getMinBlockY() : 0;
+        int maxBlockY = level.getMaxBlockY();
+        int minBlockY = level.getMinBlockY();
 
         for (int i = 0; i < 48; ++i) {
             int num = 0;

--- a/src/main/java/cn/nukkit/level/generator/object/mushroom/BigMushroom.java
+++ b/src/main/java/cn/nukkit/level/generator/object/mushroom/BigMushroom.java
@@ -3,7 +3,6 @@ package cn.nukkit.level.generator.object.mushroom;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.level.ChunkManager;
-import cn.nukkit.level.Level;
 import cn.nukkit.level.generator.object.BasicGenerator;
 import cn.nukkit.math.NukkitRandom;
 import cn.nukkit.math.Vector3;
@@ -54,8 +53,8 @@ public class BigMushroom extends BasicGenerator {
 
         boolean flag = true;
 
-        int maxY = level instanceof Level ? ((Level) level).getMaxBlockY() + 1 : 256;
-        int minBlockY = level instanceof Level ? ((Level) level).getMinBlockY() : 0;
+        int maxY = level.getMaxBlockY() + 1;
+        int minBlockY = level.getMinBlockY();
 
         if (position.getY() > minBlockY && position.getY() + i + 1 < maxY) {
             for (int j = position.getFloorY(); j <= position.getY() + 1 + i; ++j) {

--- a/src/main/java/cn/nukkit/level/generator/object/tree/HugeTreesGenerator.java
+++ b/src/main/java/cn/nukkit/level/generator/object/tree/HugeTreesGenerator.java
@@ -2,7 +2,6 @@ package cn.nukkit.level.generator.object.tree;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.level.ChunkManager;
-import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.NukkitRandom;
 import cn.nukkit.math.Vector3;
@@ -50,8 +49,8 @@ public abstract class HugeTreesGenerator extends TreeGenerator {
     private boolean isSpaceAt(ChunkManager worldIn, Vector3 leavesPos, int height) {
         boolean flag = true;
 
-        int maxY = worldIn instanceof Level ? ((Level) worldIn).getMaxBlockY() + 1 : 256;
-        int minBlockY = worldIn instanceof Level ? ((Level) worldIn).getMinBlockY() : 0;
+        int maxY = worldIn.getMaxBlockY() + 1;
+        int minBlockY = worldIn.getMinBlockY();
 
         if (leavesPos.getY() > minBlockY && leavesPos.getY() + height + 1 <= maxY) {
             for (int i = 0; i <= 1 + height; ++i) {

--- a/src/main/java/cn/nukkit/level/generator/object/tree/NewJungleTree.java
+++ b/src/main/java/cn/nukkit/level/generator/object/tree/NewJungleTree.java
@@ -5,7 +5,6 @@ import cn.nukkit.block.BlockID;
 import cn.nukkit.block.BlockLeaves;
 import cn.nukkit.block.BlockWood;
 import cn.nukkit.level.ChunkManager;
-import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.BlockVector3;
 import cn.nukkit.math.NukkitRandom;
@@ -52,8 +51,8 @@ public class NewJungleTree extends TreeGenerator {
         int i = rand.nextBoundedInt(maxTreeHeight) + this.minTreeHeight;
         boolean flag = true;
 
-        int maxY = worldIn instanceof Level ? ((Level) worldIn).getMaxBlockY() + 1 : 256;
-        int minBlockY = worldIn instanceof Level ? ((Level) worldIn).getMinBlockY() : 0;
+        int maxY = worldIn.getMaxBlockY() + 1;
+        int minBlockY = worldIn.getMinBlockY();
 
         if (position.getY() > minBlockY && position.getY() + i + 1 <= maxY) {
             for (int j = position.getY(); j <= position.getY() + 1 + i; ++j) {

--- a/src/main/java/cn/nukkit/level/generator/object/tree/ObjectAzaleaTree.java
+++ b/src/main/java/cn/nukkit/level/generator/object/tree/ObjectAzaleaTree.java
@@ -2,7 +2,6 @@ package cn.nukkit.level.generator.object.tree;
 
 import cn.nukkit.block.BlockID;
 import cn.nukkit.level.ChunkManager;
-import cn.nukkit.level.Level;
 import cn.nukkit.math.NukkitRandom;
 
 public class ObjectAzaleaTree extends ObjectTree {
@@ -33,7 +32,8 @@ public class ObjectAzaleaTree extends ObjectTree {
         int treeHeight = random.nextBoundedInt(2) + 2;
 
         int i2 = y + treeHeight;
-        int maxBlockY = level instanceof Level ? ((Level) level).getMaxBlockY() : 255;
+        int maxBlockY = level.getMaxBlockY();
+
         if (i2 + 2 >= maxBlockY) {
             return;
         }

--- a/src/main/java/cn/nukkit/level/generator/object/tree/ObjectDarkOakTree.java
+++ b/src/main/java/cn/nukkit/level/generator/object/tree/ObjectDarkOakTree.java
@@ -5,7 +5,6 @@ import cn.nukkit.block.BlockID;
 import cn.nukkit.block.BlockLeaves2;
 import cn.nukkit.block.BlockWood2;
 import cn.nukkit.level.ChunkManager;
-import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.NukkitRandom;
 import cn.nukkit.math.Vector3;
@@ -25,7 +24,7 @@ public class ObjectDarkOakTree extends TreeGenerator {
         int k = position.getFloorY();
         int l = position.getFloorZ();
 
-        int maxY = level instanceof Level ? ((Level) level).getMaxBlockY() + 1 : 256;
+        int maxY = level.getMaxBlockY() + 1;
         if (k >= 1 && k + i + 1 < maxY) {
             Vector3 blockpos = position.down();
             int block = level.getBlockIdAt(blockpos.getFloorX(), blockpos.getFloorY(), blockpos.getFloorZ());

--- a/src/main/java/cn/nukkit/level/generator/object/tree/ObjectMangroveTree.java
+++ b/src/main/java/cn/nukkit/level/generator/object/tree/ObjectMangroveTree.java
@@ -2,7 +2,6 @@ package cn.nukkit.level.generator.object.tree;
 
 import cn.nukkit.block.BlockID;
 import cn.nukkit.level.ChunkManager;
-import cn.nukkit.level.Level;
 import cn.nukkit.math.NukkitRandom;
 
 public class ObjectMangroveTree extends ObjectTree {
@@ -37,7 +36,7 @@ public class ObjectMangroveTree extends ObjectTree {
         int treeHeight = random.nextBoundedInt(3) + 8;
 
         int i2 = y + treeHeight;
-        int maxBlockY = level instanceof Level ? ((Level) level).getMaxBlockY() : 255;
+        int maxBlockY = level.getMaxBlockY();
         if (i2 + 2 >= maxBlockY) {
             return;
         }

--- a/src/main/java/cn/nukkit/level/generator/object/tree/ObjectNetherTree.java
+++ b/src/main/java/cn/nukkit/level/generator/object/tree/ObjectNetherTree.java
@@ -2,7 +2,6 @@ package cn.nukkit.level.generator.object.tree;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.level.ChunkManager;
-import cn.nukkit.level.Level;
 import cn.nukkit.math.NukkitRandom;
 
 import java.util.concurrent.ThreadLocalRandom;
@@ -29,7 +28,7 @@ public abstract class ObjectNetherTree extends ObjectTree {
 
     @Override
     public void placeObject(ChunkManager level, int x, int y, int z, NukkitRandom random) {
-        int maxBlockY = level instanceof Level ? ((Level) level).getMaxBlockY() : 255;
+        int maxBlockY = level.getMaxBlockY();
 
         if (y >= maxBlockY) {
             return;
@@ -114,7 +113,7 @@ public abstract class ObjectNetherTree extends ObjectTree {
 
     @Override
     protected void placeTrunk(ChunkManager level, int x, int y, int z, NukkitRandom random, int trunkHeight) {
-        int maxBlockY = level instanceof Level ? ((Level) level).getMaxBlockY() : 255;
+        int maxBlockY = level.getMaxBlockY();
 
         level.setBlockAt(x, y, z, getTrunkBlock());
         level.setBlockAt(x, y - 1, z, Block.NETHERRACK);

--- a/src/main/java/cn/nukkit/level/generator/object/tree/ObjectSavannaTree.java
+++ b/src/main/java/cn/nukkit/level/generator/object/tree/ObjectSavannaTree.java
@@ -5,7 +5,6 @@ import cn.nukkit.block.BlockID;
 import cn.nukkit.block.BlockLeaves2;
 import cn.nukkit.block.BlockWood2;
 import cn.nukkit.level.ChunkManager;
-import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.NukkitRandom;
 import cn.nukkit.math.Vector3;
@@ -19,8 +18,8 @@ public class ObjectSavannaTree extends TreeGenerator {
         int i = rand.nextBoundedInt(3) + rand.nextBoundedInt(3) + 5;
         boolean flag = true;
 
-        int maxY = level instanceof Level ? ((Level) level).getMaxBlockY() + 1 : 256;
-        int minBlockY = level instanceof Level ? ((Level) level).getMinBlockY() : 0;
+        int maxY = level.getMaxBlockY() + 1;
+        int minBlockY = level.getMinBlockY();
 
         if (position.getY() > minBlockY && position.getY() + i + 1 <= maxY) {
             for (int j = (int) position.getY(); j <= position.getY() + 1 + i; ++j) {

--- a/src/main/java/cn/nukkit/level/generator/object/tree/ObjectSwampTree.java
+++ b/src/main/java/cn/nukkit/level/generator/object/tree/ObjectSwampTree.java
@@ -5,7 +5,6 @@ import cn.nukkit.block.BlockID;
 import cn.nukkit.block.BlockLeaves;
 import cn.nukkit.block.BlockWood;
 import cn.nukkit.level.ChunkManager;
-import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockVector3;
 import cn.nukkit.math.NukkitRandom;
 import cn.nukkit.math.Vector3;
@@ -29,8 +28,8 @@ public class ObjectSwampTree extends TreeGenerator {
         int i = rand.nextBoundedInt(4) + 5;
         boolean flag = true;
 
-        int maxY = worldIn instanceof Level ? ((Level) worldIn).getMaxBlockY() + 1 : 256;
-        int minBlockY = worldIn instanceof Level ? ((Level) worldIn).getMinBlockY() : 0;
+        int maxY = worldIn.getMaxBlockY() + 1;
+        int minBlockY = worldIn.getMinBlockY();
 
         if (position.getY() > minBlockY && position.getY() + i + 1 <= maxY) {
             for (int j = position.getY(); j <= position.getY() + 1 + i; ++j) {

--- a/src/main/java/cn/nukkit/network/protocol/BossEventPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/BossEventPacket.java
@@ -71,6 +71,7 @@ public class BossEventPacket extends DataPacket {
                 break;
             case TYPE_TITLE:
                 this.title = this.getString();
+                this.filteredTitle = this.getString();
                 break;
         }
     }
@@ -101,6 +102,7 @@ public class BossEventPacket extends DataPacket {
                 break;
             case TYPE_TITLE:
                 this.putString(this.title);
+                this.putString(this.filteredTitle);
                 break;
         }
     }

--- a/src/main/java/cn/nukkit/potion/Effect.java
+++ b/src/main/java/cn/nukkit/potion/Effect.java
@@ -283,8 +283,7 @@ public class Effect implements Cloneable {
         }
 
         if (this.id == Effect.ABSORPTION) {
-            int add = (this.amplifier + 1) << 2;
-            if (add > entity.getAbsorption()) entity.setAbsorption(add);
+            entity.setAbsorption((this.amplifier + 1) << 2);
         }
     }
 

--- a/src/main/resources/lang/ara/lang.ini
+++ b/src/main/resources/lang/ara/lang.ini
@@ -235,6 +235,10 @@ nukkit.command.alias.illegal=Could not register alias {%0} because it contains i
 nukkit.command.alias.notFound=Could not register alias {%0} because it contains commands that do not exist: {%1}
 nukkit.command.exception=Unhandled exception executing command '{%0}' in {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Gets a list of plugins running on the server
 nukkit.command.plugins.success=Plugins ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/bra/lang.ini
+++ b/src/main/resources/lang/bra/lang.ini
@@ -251,6 +251,10 @@ nukkit.command.alias.illegal=Não foi possível registrar a alias {%0} porque el
 nukkit.command.alias.notFound=Não foi possível registrar a alias {%0} porque ela contém comandos que não existem: {%1}
 nukkit.command.exception=Exceção não tratada ao executando comando "{%0}" em {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Pega uma lista de plugins rodando no servidor
 nukkit.command.plugins.success=Plugins ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/chs/lang.ini
+++ b/src/main/resources/lang/chs/lang.ini
@@ -249,6 +249,10 @@ nukkit.command.alias.illegal=无法注册别名 {%0}，因为它包含非法字�
 nukkit.command.alias.notFound=无法注册别名 {%0}，因为它包含不存在的命令：{%1}
 nukkit.command.exception=于 {%1} 执行命令 "{%0}" 时，出现了未被处理的错误：{%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=获取服务器上运行的插件列表
 nukkit.command.plugins.success=插件 ({%0})：{%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/cht/lang.ini
+++ b/src/main/resources/lang/cht/lang.ini
@@ -249,6 +249,10 @@ nukkit.command.alias.illegal=不能註冊別名 {%0}，因為它包含非法字�
 nukkit.command.alias.notFound=未能登記別稱 {%0} ，因為它包含不存在的指令：{%1}
 nukkit.command.exception=於 {%1} 執行指令 「{%0}」 時，出現了未被處理的錯誤：{%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=取得伺服器插件列表
 nukkit.command.plugins.success=插件 ({%0})：{%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/cze/lang.ini
+++ b/src/main/resources/lang/cze/lang.ini
@@ -249,6 +249,10 @@ nukkit.command.alias.illegal=Nepodarilo se vytvorit alias {%0} protoze obsahuje 
 nukkit.command.alias.notFound=Nepodarilo se vytvorit alias {%0} protozr obsahuje prikaz, ktery neexistuje: {%1}
 nukkit.command.exception=Nezadana vyjimka pri prevadeni prikazu "{%0}" v {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Vypise list prikazu bezicich na serveru
 nukkit.command.plugins.success=Pluginy ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/deu/lang.ini
+++ b/src/main/resources/lang/deu/lang.ini
@@ -249,6 +249,10 @@ nukkit.command.alias.illegal=Konnte Alias {%0} nicht registrieren, da er unzulä
 nukkit.command.alias.notFound=Konnte Alias {%0} nicht registrieren, da er Kommandos enthält, die nicht existieren: {%1}
 nukkit.command.exception=Unbehandelter Fehler beim Ausführen des Kommandos "{%0}" in {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Gibt eine Liste aller auf dem Server laufenden Plugins zurück
 nukkit.command.plugins.success=Plugins ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/eng/lang.ini
+++ b/src/main/resources/lang/eng/lang.ini
@@ -253,6 +253,10 @@ nukkit.command.alias.illegal=Could not register alias {%0} because it contains i
 nukkit.command.alias.notFound=Could not register alias {%0} because it contains commands that do not exist: {%1}
 nukkit.command.exception=Unhandled exception executing command "{%0}" in {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Gets a list of plugins running on the server
 nukkit.command.plugins.success=Plugins ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/fin/lang.ini
+++ b/src/main/resources/lang/fin/lang.ini
@@ -247,9 +247,13 @@ nukkit.server.rcon.running=RCON on käynnissä osoitteessa {%0}:{%1}
 
 nukkit.command.alias.illegal=Aliasta {%0} ei voida rekisteröidä, koska se sisältää sopimattomia merkkejä
 nukkit.command.alias.notFound=Aliasta {%0} ei voida rekisteröidä, koska se sisältää komentoja, joita ei ole: {%1}
-nukkit.command.exception=Käsittelemätön poikkeustoiminnon komento "{%0}" {%1}: {%2}
+nukkit.command.exception=Käsittelemätön poikkeus suorittaessa komentoa "{%0}" {%1}: {%2}
 
-nukkit.command.plugins.description=Hanki lista palvelimen lisäosista
+nukkit.command.clear.description=Tyhjennä tavaraluettelo
+nukkit.command.clear.usage=/clear <pelaaja>
+commands.clear.success=Pelaajan {%0} tavaraluettelo tyyhjennettiin
+
+nukkit.command.plugins.description=Näytä lista palvelimen lisäosista
 nukkit.command.plugins.success=Lisäosat ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins
 

--- a/src/main/resources/lang/idn/lang.ini
+++ b/src/main/resources/lang/idn/lang.ini
@@ -249,6 +249,10 @@ nukkit.command.alias.illegal=Could not register alias {%0} because it contains i
 nukkit.command.alias.notFound=Could not register alias {%0} because it contains commands that do not exist: {%1}
 nukkit.command.exception=Unhandled exception executing command "{%0}" in {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Gets a list of plugins running on the server
 nukkit.command.plugins.success=Plugins ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/jpn/lang.ini
+++ b/src/main/resources/lang/jpn/lang.ini
@@ -249,6 +249,10 @@ nukkit.command.alias.illegal=無効な文字が含まれているため、{%0}�
 nukkit.command.alias.notFound=存在しないコマンドが含まれているため、{%0}を登録できませんでした: {%1}
 nukkit.command.exception=コマンド"{%0}"を{%1}で実行中に、処理できない例外が発生：{%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=サーバー上で実行されているプラグインを一覧にして表示します
 nukkit.command.plugins.success=プラグイン ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/kor/lang.ini
+++ b/src/main/resources/lang/kor/lang.ini
@@ -249,6 +249,10 @@ nukkit.command.alias.illegal=잘못된 문자를 포함하기에 '{%0}' 별칭�
 nukkit.command.alias.notFound=존재하지 않는 명령어를 포함하기에 '{%0}' 별칭을 등록할 수 없습니다: {%1}
 nukkit.command.exception={%1}에서 "{%0}" 명령어 실행 중 처리되지 않은 예외가 발생했습니다: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=서버에서 실행 중인 플러그인 목록을 확인합니다
 nukkit.command.plugins.success=플러그인({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/ltu/lang.ini
+++ b/src/main/resources/lang/ltu/lang.ini
@@ -249,6 +249,10 @@ nukkit.command.alias.illegal=Neįmanoma užregistruoti alternatyvos {%0}, nes ji
 nukkit.command.alias.notFound=Neįmanoma užregistruoti alternatyvos {%0}, nes ji turi komandų, kurios neegzistuoja: {%1}
 nukkit.command.exception=Klaida bandant įvykdyti komandą "{%0}" - {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Įskiepių sąrašas, kurį naudoja serveris
 nukkit.command.plugins.success=Įskiepiai ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/pol/lang.ini
+++ b/src/main/resources/lang/pol/lang.ini
@@ -249,6 +249,10 @@ nukkit.command.alias.illegal=Nie udalo sie zarejestrowac aliasu {%0} poniewaz za
 nukkit.command.alias.notFound=Nie udalo sie zarejestrowac aliasu {%0} poniewaz zawiera komendy, ktore nie istnieja: {%1}
 nukkit.command.exception=Nieoczekiwany wyjatek przy wykonywaniu komendy "{%0}" in {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Pobiera liste pluginow na serwerze
 nukkit.command.plugins.success=Pluginy ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/rus/lang.ini
+++ b/src/main/resources/lang/rus/lang.ini
@@ -252,6 +252,10 @@ nukkit.command.alias.illegal=Невозможно зарегистрироват
 nukkit.command.alias.notFound=Невозможно зарегистрировать альтернативу команды {%0}, поскольку она содержит недопустимые команды: {%1}
 nukkit.command.exception=Необработанное исключение при выполнении команды "{%0}" в {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Показывает список установленых плагинов на этом сервере.
 nukkit.command.plugins.success=Плагины ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/spa/lang.ini
+++ b/src/main/resources/lang/spa/lang.ini
@@ -249,6 +249,10 @@ nukkit.command.alias.illegal=Imposible registrar alias {%0} contiene caracteres 
 nukkit.command.alias.notFound=Imposible registrar alias {%0} contiene comandos que no existen: {%1}
 nukkit.command.exception=Excepcion incontrolada al ejecutar el comando "{%0}" en {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Obtén una lista de plugins ejecutandose en el servidor
 nukkit.command.plugins.success=Plugins ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/tur/lang.ini
+++ b/src/main/resources/lang/tur/lang.ini
@@ -249,6 +249,10 @@ nukkit.command.alias.illegal=Could not register alias {%0} because it contains i
 nukkit.command.alias.notFound=Could not register alias {%0} because it contains commands that do not exist: {%1}
 nukkit.command.exception=Unhandled exception executing command "{%0}" in {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Gets a list of plugins running on the server
 nukkit.command.plugins.success=Plugins ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins

--- a/src/main/resources/lang/ukr/lang.ini
+++ b/src/main/resources/lang/ukr/lang.ini
@@ -253,6 +253,10 @@ nukkit.command.alias.illegal=Не вдалось зареєструвати ал
 nukkit.command.alias.notFound=Не вдалось зареєструвати альтернативу команди {%0} оскільки вона містить команди, що не існують: {%1}
 nukkit.command.exception=Необроблене виключення при виконанні команди "{%0}" у {%1}: {%2}
 
+nukkit.command.clear.description=Clear inventory
+nukkit.command.clear.usage=/clear <player>
+commands.clear.success=Cleared the inventory of {%0}
+
 nukkit.command.plugins.description=Отримує список плагінів, які встановлено на цей сервер
 nukkit.command.plugins.success=Плагіни ({%0}): {%1}
 nukkit.command.plugins.usage=/plugins


### PR DESCRIPTION
- Fixed updating boss bar text making client disconnect
- Fixed ghost absorption hearts
- Fixed some skins not displaying properly
- Fixed painting placement checks and added new paintings from 1.21
- Fixed glow berries growing on already grown cave vines
- Fixed hopper minecart activation
- Fixed mangrove wood not working as furnace fuel
- Fixed fungus and new trees not growing past y 255
- Fixed crimson planks hardness and resistance
- Fixed turtle eggs placing wrong amount
- Fixed Player.showFormWindow returning invalid id if failed, now returns -1 instead
- Fixed drops of some deepslate ores
- Fixed missing translations for /clear
- Avoid multiple gamerule calls in level tick loop
- Mending no longer attempts to repair non damaged items
- getMin/MaxBlockY is now directly accessible through ChunkManager
